### PR TITLE
Update insecure random numbers in php.

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -88,7 +88,7 @@ class Employee extends Data
         }
 
         if($userName == '') {
-        	$userName = 'NOACCOUNT-' . mt_rand();
+        	$userName = 'NOACCOUNT-' . random_int(7, 9999999);
         }
         
         $vars = array(':firstName' => $this->sanitizeInput($firstName),

--- a/LEAF_Nexus/sources/Login.php
+++ b/LEAF_Nexus/sources/Login.php
@@ -165,14 +165,14 @@ class Login
 
     public function generateCSRFToken()
     {
-    	$_SESSION['CSRFToken'] = sha1($this->userID . mt_rand());
+    	$_SESSION['CSRFToken'] = sha1($this->userID . random_int(1, 9999999));
     }
 
     private function setSession()
     {
         $_SESSION['name'] = $this->name;
         $_SESSION['userID'] = $this->userID;
-        $_SESSION['CSRFToken'] = isset($_SESSION['CSRFToken']) ? $_SESSION['CSRFToken'] : sha1($this->userID . mt_rand());
+        $_SESSION['CSRFToken'] = isset($_SESSION['CSRFToken']) ? $_SESSION['CSRFToken'] : sha1($this->userID . random_int(1, 9999999));
     }
 
     public function loginUser()

--- a/LEAF_Request_Portal/Email.php
+++ b/LEAF_Request_Portal/Email.php
@@ -193,7 +193,7 @@ class Email
         $email['headers'] = $this->getHeaders();
 
         $emailCache = serialize($email);
-        $emailQueueName = sha1($emailCache . mt_rand(0, 9999999));
+        $emailQueueName = sha1($emailCache . random_int(0, 99999999));
         if(strlen(trim($emailCache)) == 0) {
             trigger_error('Mail error: ' . $this->emailSubject);
             return false;

--- a/LEAF_Request_Portal/Login.php
+++ b/LEAF_Request_Portal/Login.php
@@ -162,7 +162,7 @@ class Login
     {
         $_SESSION['name'] = $this->name;
         $_SESSION['userID'] = $this->userID;
-        $_SESSION['CSRFToken'] = isset($_SESSION['CSRFToken']) ? $_SESSION['CSRFToken'] : sha1($this->userID . mt_rand());
+        $_SESSION['CSRFToken'] = isset($_SESSION['CSRFToken']) ? $_SESSION['CSRFToken'] : sha1($this->userID . random_int(1, 9999999));
     }
 
     public function loginUser()

--- a/LEAF_Request_Portal/sources/FormEditor.php
+++ b/LEAF_Request_Portal/sources/FormEditor.php
@@ -212,7 +212,7 @@ class FormEditor
     function createForm($name, $description, $parentID = '', $formLibraryID = null, $categoryID = null, $workflowID = 0) {
     	$name = trim($name);
     	if($categoryID == null) {
-    	    $categoryID = 'form_' . substr(sha1($name . mt_rand()), 0, 5);
+    	    $categoryID = 'form_' . substr(sha1($name . random_int(1, 9999999)), 0, 5);
     	}
     	if($workflowID == null) {
     	    $workflowID = 0;


### PR DESCRIPTION
Updated instances of mt_rand() in php files to use random_int() instead.
mt_rand() can "randomly" generate predictable numbers.