### PR TITLE
Leaf494 and 495 sensitive indicators

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -743,7 +743,7 @@ function getForm(indicatorID, series) {
                 if(res[indicatorID].required == 1) {
                     $('#required').prop('checked', true);
                 }
-                if(res[indicatorID].sensitive == 1) {
+                if(res[indicatorID].is_sensitive == 1) {
                     $('#sensitive').prop('checked', true);
                 }
                 $('#parentID').val(res[indicatorID].parentID);

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -412,7 +412,13 @@ function newQuestion(parentIndicatorID) {
                         <td><input id="required" name="required" type="checkbox" /></td>\
                     </tr>\
                 </table>\
-        </fieldset>');
+                <table>\
+                    <tr>\
+                        <td>Sensitive</td>\
+                        <td><input id="sensitive" name="sensitive" type="checkbox" /></td>\
+                    </tr>\
+                </table>\
+            </fieldset>');
     $('#indicatorType').on('change', function() {
         switch($('#indicatorType').val()) {
             case 'radio':
@@ -437,7 +443,7 @@ function newQuestion(parentIndicatorID) {
             resetCss: true,
             btns: ['bold', 'italic', 'underline', '|', 'unorderedList', 'orderedList', '|', 'link', '|', 'foreColor', '|', 'viewHTML']
         });
-        
+
         $('.trumbowyg-box').css({
             'min-height': '130px'
         });
@@ -452,12 +458,18 @@ function newQuestion(parentIndicatorID) {
     		alert('You can\'t mark a field as required if the Input Format is "None".');
     	}
     });
+    $('#sensitive').on('click', function() {
+        if($('#indicatorType').val() == '') {
+            $('#sensitive').prop('checked', false);
+            alert('You can\'t mark a field as sensitive if the Input Format is "None".');
+        }
+    });
 
     dialog.show();
 
     dialog.setSaveHandler(function() {
     	var isRequired = $('#required').is(':checked') ? 1 : 0;
-
+        var isSensitive = $('#sensitive').is(':checked') ? 1 : 0;
         switch($('#indicatorType').val()) {
             case 'radio':
             case 'checkboxes':
@@ -476,7 +488,7 @@ function newQuestion(parentIndicatorID) {
                 $('#format').val($('#indicatorType').val());
                 break;
         }
-    	
+
         $.ajax({
             type: 'POST',
             url: '../api/?a=formEditor/newIndicator',
@@ -487,6 +499,7 @@ function newQuestion(parentIndicatorID) {
             	parentID: parentIndicatorID,
             	categoryID: currCategoryID,
             	required: isRequired,
+                is_sensitive: isSensitive,
                 CSRFToken: '<!--{$CSRFToken}-->'},
             success: function(res) {
                 if(res != null) {
@@ -530,6 +543,10 @@ function getForm(indicatorID, series) {
                     <tr>\
                         <td>Required</td>\
                         <td><input id="required" name="required" type="checkbox" /></td>\
+                    </tr>\
+                    </tr>\
+                        <td>Sensitive</td>\
+                        <td><input id="sensitive" name="sensitive" type="checkbox" /></td>\
                     </tr>\
                     <tr>\
                         <td>Sort Priority</td>\
@@ -577,6 +594,12 @@ function getForm(indicatorID, series) {
             alert('You can\'t mark a field as required if the Input Format is "None".');
         }
     });
+    $('#sensitive').on('click', function() {
+        if($('#indicatorType').val() == '') {
+            $('#sensitive').prop('checked', false);
+            alert('You can\'t mark a field as sensitive if the Input Format is "None".');
+        }
+    });
     $('#rawNameEditor').on('click', function() {
         $('#advNameEditor').css('display', 'inline');
         $('#rawNameEditor').css('display', 'none');
@@ -593,7 +616,7 @@ function getForm(indicatorID, series) {
             	'foreColor', '|',
             	'justifyLeft', 'justifyCenter', 'justifyRight']
         });
-        
+
         $('.trumbowyg-box').css({
             'min-height': '130px'
         });
@@ -673,7 +696,7 @@ function getForm(indicatorID, series) {
           }
     });
     $('.CodeMirror').css('border', '1px solid black');
-    
+
     dialog.show();
     dialog.indicateBusy();
 
@@ -720,6 +743,9 @@ function getForm(indicatorID, series) {
                 if(res[indicatorID].required == 1) {
                     $('#required').prop('checked', true);
                 }
+                if(res[indicatorID].sensitive == 1) {
+                    $('#sensitive').prop('checked', true);
+                }
                 $('#parentID').val(res[indicatorID].parentID);
                 $('#sort').val(res[indicatorID].sort);
                 codeEditorHtml.setValue((res[indicatorID].html == null ? '' : res[indicatorID].html));
@@ -750,9 +776,10 @@ function getForm(indicatorID, series) {
             cache: false
         });
     });
-    
+
     dialog.setSaveHandler(function() {
     	var isRequired = $('#required').is(':checked') ? 1 : 0;
+        var isSensitive = $('#sensitive').is(':checked') ? 1 : 0;
     	var isDisabled = $('#disabled').is(':checked') ? 1 : 0;
 
         switch($('#indicatorType').val()) {
@@ -835,6 +862,16 @@ function getForm(indicatorID, series) {
    	                }
    	            }
    	        }),
+            $.ajax({
+                type: 'POST',
+                url: '../api/?a=formEditor/' + indicatorID + '/sensitive',
+                data: {is_sensitive: isSensitive,
+                CSRFToken: '<!--{$CSRFToken}-->'},
+                success: function(res) {
+                    if(res != null) {
+                    }
+                }
+            }),
    	        $.ajax({
    	            type: 'POST',
    	            url: '../api/?a=formEditor/' + indicatorID + '/disabled',

--- a/LEAF_Request_Portal/api/controllers/FormEditorController.php
+++ b/LEAF_Request_Portal/api/controllers/FormEditorController.php
@@ -79,6 +79,7 @@ class FormEditorController extends RESTfulResponse
         	$package['html'] = $_POST['html'];
         	$package['htmlPrint'] = $_POST['htmlPrint'];
         	$package['required'] = $_POST['required'];
+            $package['is_sensitive'] = $_POST['is_sensitive'];
         	$package['sort'] = $_POST['sort'];
         	return $formEditor->addIndicator($package);
 		});
@@ -110,8 +111,12 @@ class FormEditorController extends RESTfulResponse
         $this->index['POST']->register('formEditor/[digit]/required', function($args) use ($formEditor) {
         	return $formEditor->setRequired($args[0], $_POST['required']);
         });
-        
-       	$this->index['POST']->register('formEditor/[digit]/disabled', function($args) use ($formEditor) {
+
+        $this->index['POST']->register('formEditor/[digit]/sensitive', function($args) use ($formEditor) {
+            return $formEditor->setSensitive($args[0], $_POST['is_sensitive']);
+        });
+
+        $this->index['POST']->register('formEditor/[digit]/disabled', function($args) use ($formEditor) {
        		return $formEditor->setDisabled($args[0], $_POST['disabled']);
        	});
 

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -432,6 +432,7 @@ class Form
 
         $required = isset($data[0]['required']) && $data[0]['required'] == 1 ? ' required="true" ' : '';
 
+
         $idx = $data[0]['indicatorID'];
         $form[$idx]['indicatorID'] = $data[0]['indicatorID'];
         $form[$idx]['series'] = $series;
@@ -444,6 +445,7 @@ class Form
         $form[$idx]['htmlPrint'] = $parseTemplate ? str_replace('{{ iID }}', $idx, $data[0]['htmlPrint'])
                                 : $data[0]['htmlPrint'];
         $form[$idx]['required'] = $data[0]['required'];
+        $form[$idx]['is_sensitive'] = $data[0]['is_sensitive'];
         $form[$idx]['isEmpty'] = (isset($data[0]['data']) && !is_array($data[0]['data']) && strip_tags($data[0]['data']) != '') ? false : true;
         $form[$idx]['value'] = (isset($data[0]['data']) && $data[0]['data'] != '') ? $data[0]['data'] : $form[$idx]['default'];
         $form[$idx]['value'] = @unserialize($form[$idx]['value']) === false ? $form[$idx]['value'] : unserialize($form[$idx]['value']);
@@ -3000,6 +3002,7 @@ class Form
                 $child[$idx]['htmlPrint'] = $parseTemplate ? str_replace('{{ iID }}', $idx, $field['htmlPrint'])
                                                 : $field['htmlPrint'];
                 $child[$idx]['required'] = $field['required'];
+                $child[$idx]['is_sensitive'] = $field['is_sensitive'];
                 $child[$idx]['isEmpty'] = (isset($data[$idx]['data']) && !is_array($data[$idx]['data']) && strip_tags($data[$idx]['data']) != '') ? false : true;
                 $child[$idx]['value'] = (isset($data[$idx]['data']) && $data[$idx]['data'] != '') ? $data[$idx]['data'] : $child[$idx]['default'];
                 $child[$idx]['value'] = @unserialize($data[$idx]['data']) === false ? $child[$idx]['value'] : unserialize($data[$idx]['data']);

--- a/LEAF_Request_Portal/sources/FormEditor.php
+++ b/LEAF_Request_Portal/sources/FormEditor.php
@@ -40,10 +40,11 @@ class FormEditor
     	        ':html' => $package['html'],
     	        ':htmlPrint' => $package['htmlPrint'],
     	        ':required' => $package['required'],
+                ':is_sensitive' => $package['is_sensitive'], //new stuff
     	        ':sort' => isset($package['sort']) ? $package['sort'] : 1);
 
-    	    $this->db->prepared_query('INSERT INTO indicators (indicatorID, name, format, description, `default`, parentID, categoryID, html, htmlPrint, required, sort, timeAdded, disabled)
-            								VALUES (null, :name, :format, :description, :default, :parentID, :categoryID, :html, :htmlPrint, :required, :sort, CURRENT_TIMESTAMP, 0)', $vars);
+    	    $this->db->prepared_query('INSERT INTO indicators (indicatorID, name, format, description, `default`, parentID, categoryID, html, htmlPrint, required, is_sensitive /* new stuff */, sort, timeAdded, disabled)
+            								VALUES (null, :name, :format, :description, :default, :parentID, :categoryID, :html, :htmlPrint, :required, :is_sensitive /* new stuff */, :sort, CURRENT_TIMESTAMP, 0)', $vars);
     	}
     	else {
     	    $vars = array(':indicatorID' => $package['indicatorID'],
@@ -56,11 +57,12 @@ class FormEditor
     	        ':html' => $package['html'],
     	        ':htmlPrint' => $package['htmlPrint'],
     	        ':required' => $package['required'],
+    	        ':is_sensitive' => $package['is_sensitive'], //
     	        ':sort' => isset($package['sort']) ? $package['sort'] : 1);
 
-    	    $this->db->prepared_query('INSERT INTO indicators (indicatorID, name, format, description, `default`, parentID, categoryID, html, htmlPrint, required, sort, timeAdded, disabled)
-            								VALUES (:indicatorID, :name, :format, :description, :default, :parentID, :categoryID, :html, :htmlPrint, :required, :sort, CURRENT_TIMESTAMP, 0)
-                                            ON DUPLICATE KEY UPDATE name=:name, format=:format, description=:description, `default`=:default, parentID=:parentID, categoryID=:categoryID, html=:html, htmlPrint=:htmlPrint, required=:required, sort=:sort', $vars);
+    	    $this->db->prepared_query('INSERT INTO indicators (indicatorID, name, format, description, `default`, parentID, categoryID, html, htmlPrint, required, is_sensitive /* new stuff */, sort, timeAdded, disabled)
+            								VALUES (:indicatorID, :name, :format, :description, :default, :parentID, :categoryID, :html, :htmlPrint, :required, :is_sensitive /* new stuff */,:sort, CURRENT_TIMESTAMP, 0)
+                                            ON DUPLICATE KEY UPDATE name=:name, format=:format, description=:description, `default`=:default, parentID=:parentID, categoryID=:categoryID, html=:html, htmlPrint=:htmlPrint, required=:required, is_sensitive=:is_sensitive /* new stuff */,sort=:sort', $vars);
     	}
 
     	return $this->db->getLastInsertID();
@@ -150,6 +152,14 @@ class FormEditor
     				  ':input' => $input);
     	return $this->db->prepared_query('UPDATE indicators
     								SET required=:input
+    								WHERE indicatorID=:indicatorID', $vars);
+    }
+
+    function setSensitive($indicatorID, $input) {
+        $vars = array(':indicatorID' => $indicatorID,
+            ':input' => $input);
+        return $this->db->prepared_query('UPDATE indicators
+    								SET is_sensitive=:input
     								WHERE indicatorID=:indicatorID', $vars);
     }
     

--- a/LEAF_Request_Portal/sources/FormEditor.php
+++ b/LEAF_Request_Portal/sources/FormEditor.php
@@ -156,8 +156,8 @@ class FormEditor
     }
 
     function setSensitive($indicatorID, $input) {
-	if(is_int($input) == false){
-            return 'Not an integer';
+	if(is_int((int)$input) == false){
+            return "invalid entry";
         }
         $vars = array(':indicatorID' => $indicatorID,
             ':input' => $input);

--- a/test/LEAF_Request_Portal_Tests/db/seeds/BaseTestSeed.php
+++ b/test/LEAF_Request_Portal_Tests/db/seeds/BaseTestSeed.php
@@ -54,14 +54,14 @@ class BaseTestSeed extends AbstractSeed
             (3, NULL, 'Another Test Group', 'Another Group for Testing');
 
             INSERT INTO `indicators` 
-            (`indicatorID`, `name`, `format`, `description`, `default`, `parentID`, `categoryID`, `html`, `htmlPrint`, `jsSort`, `required`, `sort`, `timeAdded`, `disabled`) VALUES
-            (1, 'A Very Simple Form', '', '', '', NULL, 'form_f4687', NULL, NULL, NULL, 0, 1, '2018-03-05 16:52:15', 0),
-            (2, 'First Name', 'text', 'First Name', '', NULL, 'form_f4687', NULL, NULL, NULL, 1, 1, '2018-03-05 16:52:40', 0),
-            (3, 'Last Name', 'text', 'Last Name', '', NULL, 'form_f4687', NULL, NULL, NULL, 1, 1, '2018-03-05 16:52:54', 0),
-            (4, 'Occupation', 'text', 'Occupation', '', NULL, 'form_f4687', NULL, NULL, NULL, 0, 1, '2018-03-05 16:53:06', 0),
-            (5, 'Hobbies', 'textarea', 'Hobbies', '', NULL, 'form_f4687', NULL, NULL, NULL, 0, 1, '2018-03-05 16:53:30', 0),
-            (6, 'Favorite Day', 'date', 'favorite day', '', NULL, 'form_f4687', NULL, NULL, NULL, 1, 1, '2018-03-05 16:53:52', 0),
-            (7, 'Masked', 'text', 'Masked', '', NULL, 'form_f4687', NULL, NULL, NULL, 1, 1, '2018-03-05 16:53:52', 0);
+            (`indicatorID`, `name`, `format`, `description`, `default`, `parentID`, `categoryID`, `html`, `htmlPrint`, `jsSort`, `required`, `sort`, `timeAdded`, `disabled`, `is_sensitive`) VALUES
+            (1, 'A Very Simple Form', '', '', '', NULL, 'form_f4687', NULL, NULL, NULL, 0, 1, '2018-03-05 16:52:15', 0, 1),
+            (2, 'First Name', 'text', 'First Name', '', NULL, 'form_f4687', NULL, NULL, NULL, 1, 1, '2018-03-05 16:52:40', 0, 0),
+            (3, 'Last Name', 'text', 'Last Name', '', NULL, 'form_f4687', NULL, NULL, NULL, 1, 1, '2018-03-05 16:52:54', 0, 0),
+            (4, 'Occupation', 'text', 'Occupation', '', NULL, 'form_f4687', NULL, NULL, NULL, 0, 1, '2018-03-05 16:53:06', 0, 1),
+            (5, 'Hobbies', 'textarea', 'Hobbies', '', NULL, 'form_f4687', NULL, NULL, NULL, 0, 1, '2018-03-05 16:53:30', 0, 1),
+            (6, 'Favorite Day', 'date', 'favorite day', '', NULL, 'form_f4687', NULL, NULL, NULL, 1, 1, '2018-03-05 16:53:52', 0, 0),
+            (7, 'Masked', 'text', 'Masked', '', NULL, 'form_f4687', NULL, NULL, NULL, 1, 1, '2018-03-05 16:53:52', 0, 0);
 
             INSERT INTO `indicator_mask`
             (`indicatorID`, `groupID`) VALUES

--- a/test/LEAF_Request_Portal_Tests/tests/api/FormControllerTest.php
+++ b/test/LEAF_Request_Portal_Tests/tests/api/FormControllerTest.php
@@ -48,6 +48,7 @@ final class FormTest extends DatabaseTest
         $this->assertEquals('A Very Simple Form', $ind1['name']);
         $this->assertNull($ind1['parentID']);
         $this->assertEquals('0', $ind1['required']);
+        $this->assertEquals('0', $ind1['is_sensitive']);
         $this->assertTrue($ind1['isEmpty']);
         $this->assertEquals('', $ind1['format']);
 
@@ -58,6 +59,7 @@ final class FormTest extends DatabaseTest
         $this->assertEquals('First Name', $ind2['description']);
         $this->assertNull($ind2['parentID']);
         $this->assertEquals('1', $ind2['required']);
+        $this->assertEquals('1', $ind2['is_sensitive']);
         $this->assertFalse($ind2['isEmpty']);
         $this->assertEquals('text', $ind2['format']);
         $this->assertEquals('1520268869', $ind2['timestamp']);
@@ -70,6 +72,7 @@ final class FormTest extends DatabaseTest
         $this->assertEquals('Hobbies', $ind5['description']);
         $this->assertNull($ind5['parentID']);
         $this->assertEquals('0', $ind5['required']);
+        $this->assertEquals('1', $ind5['is_sensitive']);
         $this->assertFalse($ind5['isEmpty']);
         $this->assertEquals('textarea', $ind5['format']);
         $this->assertEquals('1520268912', $ind5['timestamp']);
@@ -82,6 +85,7 @@ final class FormTest extends DatabaseTest
         $this->assertEquals('favorite day', $ind6['description']);
         $this->assertNull($ind6['parentID']);
         $this->assertEquals('1', $ind6['required']);
+        $this->assertEquals('0', $ind6['is_sensitive']);
         $this->assertFalse($ind6['isEmpty']);
         $this->assertEquals('date', $ind6['format']);
         $this->assertEquals('1520268896', $ind6['timestamp']);

--- a/test/LEAF_Request_Portal_Tests/tests/api/FormEditorControllerTest.php
+++ b/test/LEAF_Request_Portal_Tests/tests/api/FormEditorControllerTest.php
@@ -45,6 +45,7 @@ final class FormEditorControllerTest extends DatabaseTest
         $this->assertEquals(null, $ind['html']);
         $this->assertEquals(null, $ind['htmlPrint']);
         $this->assertEquals('1', $ind['required']);
+        $this->assertEquals('1', $ind['is_sensitive']);
         $this->assertEquals(true, $ind['isEmpty']);
         $this->assertEquals('', $ind['value']);
         $this->assertEquals('', $ind['displayedValue']);
@@ -76,6 +77,7 @@ final class FormEditorControllerTest extends DatabaseTest
         $this->assertEquals(null, $ind['html']);
         $this->assertEquals(null, $ind['htmlPrint']);
         $this->assertEquals(null, $ind['required']);
+        $this->assertEquals(null, $ind['is_sensitive']);
         $this->assertEquals(true, $ind['isEmpty']);
         $this->assertEquals(null, $ind['value']);
         $this->assertEquals('', $ind['displayedValue']);
@@ -131,6 +133,7 @@ final class FormEditorControllerTest extends DatabaseTest
             'html' => null,
             'htmlPrint' => null,
             'required' => 0,
+            'is_sensitive' => 0,
             'sort' => 1,
         );
 
@@ -148,6 +151,7 @@ final class FormEditorControllerTest extends DatabaseTest
         $this->assertEquals(null, $indicator['8']['html']);
         $this->assertEquals(null, $indicator['8']['htmlPrint']);
         $this->assertEquals(0, $indicator['8']['required']);
+        $this->assertEquals(0, $indicator['8']['is_sensitive']);
         $this->assertEquals(1, $indicator['8']['sort']);
     }
 
@@ -174,6 +178,7 @@ final class FormEditorControllerTest extends DatabaseTest
             'html' => "<script lang='javascript'>alert('hi')</script><b>the html</b>",
             'htmlPrint' => "<script lang='javascript'>alert('hi')</script><b>the html</b>",
             'required' => 0,
+            'is_sensitive' => 0,
             'sort' => 1,
         );
 
@@ -191,6 +196,7 @@ final class FormEditorControllerTest extends DatabaseTest
         $this->assertEquals("<script lang='javascript'>alert('hi')</script><b>the html</b>", $indicator['8']['html']); // Advanced Option allows HTML/JS
         $this->assertEquals("<script lang='javascript'>alert('hi')</script><b>the html</b>", $indicator['8']['htmlPrint']); // Advanced Option allows HTML/JS
         $this->assertEquals(0, $indicator['8']['required']);
+        $this->assertEquals(0, $indicator['8']['is_sensitive']);
         $this->assertEquals(1, $indicator['8']['sort']);
     }
 
@@ -413,6 +419,24 @@ final class FormEditorControllerTest extends DatabaseTest
 
         $this->assertNotNull($indicator);
         $this->assertEquals('0', $indicator['6']['required']);
+    }
+
+    /**
+     * Tests the `formEditor/[digit]/sensitive` endpoint.
+     */
+    public function testSetIndicatorSensitive() : void
+    {
+        $indicator = self::$client->get('?a=formEditor/indicator/6');
+
+        $this->assertNotNull($indicator);
+        $this->assertEquals('1', $indicator['6']['is_sensitive']);
+
+        self::$client->postEncodedForm('?a=formEditor/6/sensitive', array('is_sensitive' => '0'));
+
+        $indicator = self::$client->get('?a=formEditor/indicator/6');
+
+        $this->assertNotNull($indicator);
+        $this->assertEquals('0', $indicator['6']['is_sensitive']);
     }
 
     /**


### PR DESCRIPTION
added "sensitive" attribute to form editor and implemented persistency.  In addition, updated the test files the "sensitive" attribute added in.