### PR TITLE
Workaround to cleanup copy/pasted content

### DIFF
--- a/LEAF_Request_Portal/index.php
+++ b/LEAF_Request_Portal/index.php
@@ -461,7 +461,7 @@ switch ($action) {
         $t_form->right_delimiter = '}-->';
 
         $t_form->assign('userID', XSSHelpers::sanitizeHTML($login->getUserID()));
-        $t_form->assign('empUID', XSSHelpers::sanitizeHTML($login->getEmpUID()));
+        $t_form->assign('empUID', (int)$login->getEmpUID());
         $t_form->assign('empMembership', $login->getMembership());
         $t_form->assign('is_service_chief', (bool)$login->isServiceChief());
         $t_form->assign('is_quadrad', (bool)$login->isQuadrad() || (bool)$login->checkGroup(1));

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -1,7 +1,7 @@
 <!--{**}-->
         <!--{if $indicator.format == 'textarea'}-->
             <span class="printResponse" id="data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->">
-                <!--{$indicator.value|replace:'  ':'&nbsp;&nbsp;'|sanitizeRichtext}-->
+                <!--{$indicator.value|replace:'  ':'&nbsp;&nbsp;'|sanitize}-->
             </span>
             <!--{$indicator.htmlPrint}-->
         <!--{/if}-->

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -1,7 +1,7 @@
 <!--{**}-->
         <!--{if $indicator.format == 'textarea'}-->
             <span class="printResponse" id="data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->">
-                <!--{$indicator.value|replace:'  ':'&nbsp;&nbsp;'|sanitize}-->
+                <!--{$indicator.value|replace:'  ':'&nbsp;&nbsp;'|sanitizeRichtext}-->
             </span>
             <!--{$indicator.htmlPrint}-->
         <!--{/if}-->

--- a/libs/php-commons/XSSHelpers.php
+++ b/libs/php-commons/XSSHelpers.php
@@ -49,10 +49,11 @@ class XSSHelpers {
      *
      * @param    string  $in the string to be sanitized
      * @param    string  $allowedTags list of allowed tags in strip_tags format
+     * @param    string  $encoding define the character encoding
      *
      * @return   string  the sanitized string
      */
-    static public function sanitizer($in, $allowedTags, $encoding = 'UTF-8') {
+    static public function sanitizer($in, $allowedTags = [], $encoding = 'UTF-8') {
         // replace linebreaks with <br /> if there's no html <p>'s
         if(strpos($in, '<p>') === false
             && strpos($in, '<table') === false) {

--- a/libs/php-commons/XSSHelpers.php
+++ b/libs/php-commons/XSSHelpers.php
@@ -92,22 +92,26 @@ class XSSHelpers {
                 case 'p':
                     $pattern[] = '/&lt;p style=&(quot|#039);(\S.+)&(quot|#039);(\s.+)?&gt;/Ui';
                     $replace[] = '<p style="\2">';
-                    $pattern[] = '/&lt;p(\s.+)?&gt;/Ui';
-                    $replace[] = '<p>';
                     $pattern[] = '/&lt;\/p&gt;/Ui';
                     $replace[] = '</p>';
                     
                     // IE 11 workarounds
                     $pattern[] = '/&lt;p align=&quot;(\S.+)&quot;(\s.+)?&gt;/Ui';
                     $replace[] = '<p align="\1">';
+                    
+                    // cleanup
+                    $pattern[] = '/&lt;p(\s.+)?&gt;/Ui';
+                    $replace[] = '<p>';
                     break;
                 case 'span':
                     $pattern[] = '/&lt;span style=&(quot|#039);(\S.+)&(quot|#039);(\s.+)?&gt;/Ui';
                     $replace[] = '<span style="\2">';
-                    $pattern[] = '/&lt;span(\s.+)?&gt;/Ui';
-                    $replace[] = '<span>';
                     $pattern[] = '/&lt;\/span&gt;/Ui';
                     $replace[] = '</span>';
+                    
+                    // cleanup
+                    $pattern[] = '/&lt;span(\s.+)?&gt;/Ui';
+                    $replace[] = '<span>';
                     break;
                 case 'img':
                     $pattern[] = '/&lt;img src=&(?:quot|#039);(?!javascript)(.+)&(?:quot|#039); alt=&(?:quot|#039);(.+)&(?:quot|#039);(\s.*)?\/?&gt;/Ui';
@@ -123,6 +127,18 @@ class XSSHelpers {
                     $replace[] = '</font>';
                     break;
                 // End IE 11 workarounds
+                // Start table related support
+                case 'col':
+                    $pattern[] = '/&lt;col style=&(quot|#039);(.+)&(quot|#039); width=&(quot|#039);(.+)&(quot|#039); span=&(quot|#039);(.+)&(quot|#039);(\s.+)?&gt;/Ui';
+                    $replace[] = '<col style="\2" width="\5" span="\8">';
+                    break;
+                case 'td':
+                    $pattern[] = '/&lt;td(\s.+)?&gt;/U';
+                    $replace[] = '<td>';
+                    $pattern[] = '/&lt;\/td(\s.+)?&gt;/U';
+                    $replace[] = '</td>';
+                    break;
+                // End table related support
                 default:
                     $pattern[] = '/&lt;(\/)?'. $tag .'(\s.+)?&gt;/U';
                     $replace[] = '<\1'. $tag .'>';
@@ -143,7 +159,8 @@ class XSSHelpers {
         $numTags = count($matches[2]);
         for($i = 0; $i < $numTags; $i++) {
             if($matches[2][$i] != 'br'
-                && $matches[2][$i] != 'img') {
+                && $matches[2][$i] != 'img'
+                && $matches[2][$i] != 'col') {
                 //echo "examining: {$matches[1][$i]}{$matches[2][$i]}\n";
                 // proper closure
                 if($matches[1][$i] == '/' && isset($openTags[$matches[2][$i]]) && $openTags[$matches[2][$i]] > 0) {
@@ -191,7 +208,9 @@ class XSSHelpers {
     */
     static public function sanitizeHTML($in)
     {
-        $allowedTags = ['b', 'i', 'u', 'strong', 'em', 'ol', 'ul', 'li', 'br', 'p', 'table', 'td', 'tr', 'thead', 'tbody'];
+        $allowedTags = ['b', 'i', 'u', 'ol', 'ul', 'li', 'br', 'p', 'table',
+                        'td', 'tr', 'thead', 'tbody', 'strong', 'em',
+                        'colgroup', 'col'];
 
         return XSSHelpers::sanitizer($in, $allowedTags);
     }
@@ -210,7 +229,8 @@ class XSSHelpers {
     {
         $allowedTags = ['b', 'i', 'u', 'ol', 'ul', 'li', 'br', 'p', 'table',
                         'td', 'tr', 'thead', 'tbody', 'a', 'span', 'strong',
-                        'em', 'h1', 'h2', 'h3', 'h4', 'img'];
+                        'em', 'h1', 'h2', 'h3', 'h4', 'img', 'colgroup',
+                        'col'];
 
         // IE 11 workarounds
         $allowedTags[] = 'font';

--- a/libs/php-commons/XSSHelpers.php
+++ b/libs/php-commons/XSSHelpers.php
@@ -58,10 +58,7 @@ class XSSHelpers {
             && strpos($in, '<table') === false) {
             $in = nl2br($in, true);
         }
-        
-        // strip out uncommon characters
-        $in = preg_replace('/[^\040-\176]/', '', $in);
-        
+
         // hard character limit of 65535
         $in = strlen($in) > 65535 ? substr($in, 0, 65535) : $in;
         
@@ -95,7 +92,7 @@ class XSSHelpers {
                 case 'p':
                     $pattern[] = '/&lt;p style=&(quot|#039);(\S.+)&(quot|#039);(\s.+)?&gt;/Ui';
                     $replace[] = '<p style="\2">';
-                    $pattern[] = '/&lt;p&gt;/Ui';
+                    $pattern[] = '/&lt;p(\s.+)?&gt;/Ui';
                     $replace[] = '<p>';
                     $pattern[] = '/&lt;\/p&gt;/Ui';
                     $replace[] = '</p>';
@@ -107,6 +104,8 @@ class XSSHelpers {
                 case 'span':
                     $pattern[] = '/&lt;span style=&(quot|#039);(\S.+)&(quot|#039);(\s.+)?&gt;/Ui';
                     $replace[] = '<span style="\2">';
+                    $pattern[] = '/&lt;span(\s.+)?&gt;/Ui';
+                    $replace[] = '<span>';
                     $pattern[] = '/&lt;\/span&gt;/Ui';
                     $replace[] = '</span>';
                     break;
@@ -160,7 +159,7 @@ class XSSHelpers {
                     // echo "open\n";
                 }
                 // improper closure
-                else if($matches[1][$i] == '/' && isset($openTags[$matches[2][$i]]) && $openTags[$matches[2][$i]] <= 0) {
+                else if($matches[1][$i] == '/' && isset($openTags[$matches[2][$i]]) || $openTags[$matches[2][$i]] <= 0) {
                     $in = '<' . $matches[2][$i] . '>' . $in;
                     $openTags[$matches[2][$i]]--;
                     // echo "improper\n";

--- a/libs/php-commons/XSSHelpers.php
+++ b/libs/php-commons/XSSHelpers.php
@@ -210,8 +210,12 @@ class XSSHelpers {
     static public function sanitizeHTML($in)
     {
         $allowedTags = ['b', 'i', 'u', 'ol', 'ul', 'li', 'br', 'p', 'table',
-                        'td', 'tr', 'thead', 'tbody', 'strong', 'em',
+                        'td', 'tr', 'thead', 'tbody', 'span', 'strong', 'em',
                         'colgroup', 'col'];
+
+        // IE 11 workarounds
+        $allowedTags[] = 'font';
+        $allowedTags[] = 'center';
 
         return XSSHelpers::sanitizer($in, $allowedTags);
     }


### PR DESCRIPTION
Content copy/pasted from rich text documents sometimes leads to the addition of XML tags that the user did not intend on including