### PR TITLE
Allow "Unassigned" employee selector

### DIFF
--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -627,6 +627,8 @@
                             	$('#<!--{$indicator.indicatorID|strip_tags}-->').val(res);
                             }
                         });
+                    } else {
+                        $('#<!--{$indicator.indicatorID|strip_tags}-->').val('');
                     }
                 }
 


### PR DESCRIPTION
If a user selects an Employee from the employee selector for a form
indicator value, previously they were not allowed to set that indicator
as "Unassigned". The selector would persist the previous value. Now a
user can clear out that indicator data.