### PR TITLE
LEA774_ATO_scrub_file_name

### DIFF
--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -554,7 +554,7 @@ class System
     public function newFile()
     {
         $in = $_FILES['file']['name'];
-        // $fileName = XSSHelpers::scrubFilename($in);
+        $fileName = XSSHelpers::scrubFilename($in);
         $fileName = $in;
         if ($fileName != $in
                 || $fileName == 'index.html'
@@ -576,7 +576,6 @@ class System
             return 'Admin access required';
         }
 
-        // XSSHelpers::scrubFilename($_FILES['file']['tmp_name']) . '   ' . __DIR__ . '/../files/' . $fileName;
         move_uploaded_file($_FILES['file']['tmp_name'], __DIR__ . '/../files/' . $fileName);
 
         return true;


### PR DESCRIPTION
Initially, $_FILES['file']['tmp_name'] was being scrubbed, but this is a filepath defined by the server, so can't be tainted by user input. The filename given by the user is scrubbed for illegal characters. 

Can be tested at portal/admin/?a=mod_file_manager