### PR TITLE
LEAF778 ATO path manipulation

### DIFF
--- a/libs/dynicons/index.php
+++ b/libs/dynicons/index.php
@@ -43,7 +43,7 @@ class Dynicon
 
     public function __construct($file, $width)
     {
-        // $file = XSSHelpers::scrubFilename($file);
+        $file = XSSHelpers::scrubFilename($file);
         $this->file = $file;
         $this->width = $width;
         if (!is_numeric($width) || $width <= 0)


### PR DESCRIPTION
The file name scrubber used to use a whitelist, but is now a blacklist for illegal characters. This is for the icons that show up throughout the application.