### PR TITLE
Internet Explorer specific fix for formGrid.js

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -684,7 +684,11 @@ var LeafFormGrid = function(containerID, options) {
 			download.style.display = 'none';
 
 			document.body.appendChild(download);
-			download.click();
+			if (navigator.msSaveBlob) {
+				navigator.msSaveBlob(new Blob([rows], {type: 'text/csv;charset=utf-8;'}), "Exported_" + now + ".csv");
+			} else {
+				download.click();
+			}
 			document.body.removeChild(download);
     	});
     }


### PR DESCRIPTION
Generating CSV for the Report Builder export was switched to a Javascript
implementation from a "converter" endpoint.

Some versions of IE need to handle the download of that CSV a little
differently.