### PR TITLE
supress warnings in sanitizer

### DIFF
--- a/libs/php-commons/XSSHelpers.php
+++ b/libs/php-commons/XSSHelpers.php
@@ -61,6 +61,7 @@ class XSSHelpers
      */
     public static function sanitizer($in, $allowedTags = array(), $encoding = 'UTF-8')
     {
+        $errorReportingLevel = error_reporting(0);//turn off errors for the next few lines
         // replace linebreaks with <br /> if there's no html <p>'s
         if (strpos($in, '<p>') === false
             && strpos($in, '<table') === false)
@@ -78,6 +79,7 @@ class XSSHelpers
         {
             $in = strip_tags($in, '<br>');
         }
+        error_reporting($errorReportingLevel);//turn errors back on
 
         $pattern = array();
         $replace = array();

--- a/libs/php-commons/XSSHelpers.php
+++ b/libs/php-commons/XSSHelpers.php
@@ -61,7 +61,7 @@ class XSSHelpers
      */
     public static function sanitizer($in, $allowedTags = array(), $encoding = 'UTF-8')
     {
-        $errorReportingLevel = error_reporting(0);//turn off errors for the next few lines
+        $errorReportingLevel = error_reporting(E_ALL ^ E_WARNING);//turn off errors for the next few lines
         // replace linebreaks with <br /> if there's no html <p>'s
         if (strpos($in, '<p>') === false
             && strpos($in, '<table') === false)


### PR DESCRIPTION
There are tons of warnings clogging up the error logs, but nothing is functionally broken. We're just turning the warnings off.