### PR TITLE
hotfix for gridInput dropdown

### DIFF
--- a/LEAF_Request_Portal/js/gridInput.js
+++ b/LEAF_Request_Portal/js/gridInput.js
@@ -78,7 +78,7 @@ function printTableInput(gridParameters, values, indicatorID, series){
                 var newCoordinates = gridBodyElement + ' > tr:eq(' + i + ') > td:eq(' + columnOrder.indexOf(values.columns[j]) + ')';
                 switch ($(newCoordinates).children().first().prop("tagName")) {
                     case 'SELECT':
-                        $(newCoordinates + ' > select > option[value=' + value + ']').attr('selected', 'selected');
+                        $(newCoordinates + ' > select').val(value);
                         break;
                     case 'TEXTAREA':
                         $(newCoordinates + ' > textarea').val(value);


### PR DESCRIPTION
when selecting the saved option from a dropdown that contained special characters or spaces, it would fail and throw a javascript error.  Changing how it is selected fixes it.