### PR TITLE
LEAF964 orgchart employee fix

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -127,7 +127,7 @@ class Employee extends Data
     {
         if ($userName == '')
         {
-            return 'Invalid user';
+            return '';
         }
 
         // first see if the username already exists

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -698,8 +698,7 @@
                     });
                 }
                 function importFromNational(empSel) {
-                    if(empSel.selection != '') {
-                        var selectedUserName = empSel.selectionData[empSel.selection].userName;
+                        var selectedUserName = empSel.selection !== '' ? empSel.selectionData[empSel.selection].userName : '';
                         $.ajax({
                             type: 'POST',
                             url: '<!--{$orgchartPath}-->/api/employee/import/_' + selectedUserName,
@@ -708,7 +707,6 @@
                             	$('#<!--{$indicator.indicatorID|strip_tags}-->').val(res);
                             }
                         });
-                    }
                 }
 
             	var empSel;

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -698,15 +698,15 @@
                     });
                 }
                 function importFromNational(empSel) {
-                        var selectedUserName = empSel.selection !== '' ? empSel.selectionData[empSel.selection].userName : '';
-                        $.ajax({
-                            type: 'POST',
-                            url: '<!--{$orgchartPath}-->/api/employee/import/_' + selectedUserName,
-                            data: {CSRFToken: '<!--{$CSRFToken}-->'},
-                            success: function(res) {
-                            	$('#<!--{$indicator.indicatorID|strip_tags}-->').val(res);
-                            }
-                        });
+                    var selectedUserName = empSel.selection !== '' ? empSel.selectionData[empSel.selection].userName : '';
+                    $.ajax({
+                        type: 'POST',
+                        url: '<!--{$orgchartPath}-->/api/employee/import/_' + selectedUserName,
+                        data: {CSRFToken: '<!--{$CSRFToken}-->'},
+                        success: function(res) {
+                            $('#<!--{$indicator.indicatorID|strip_tags}-->').val(res);
+                        }
+                    });
                 }
 
             	var empSel;


### PR DESCRIPTION
Allowed unassigning of employee via clearing input box.  To test, answer an org chart employee indicator question and save. Finally, open the question again and clear the field.   Employee should now show up as unassigned on the printview page.