### PR TITLE
LEAF979 grid input inbox fix

### DIFF
--- a/LEAF_Request_Portal/index.php
+++ b/LEAF_Request_Portal/index.php
@@ -261,7 +261,7 @@ switch ($action) {
         break;
     case 'inbox':
         $main->assign('useUI', true);
-        $main->assign('javascripts', array('js/form.js', 'js/workflow.js', 'js/formGrid.js'));
+        $main->assign('javascripts', array('js/form.js', 'js/workflow.js', 'js/formGrid.js', 'js/gridInput.js'));
 
         $t_form = new Smarty;
         $t_form->left_delimiter = '<!--{';

--- a/LEAF_Request_Portal/templates/view_inbox.tpl
+++ b/LEAF_Request_Portal/templates/view_inbox.tpl
@@ -36,6 +36,7 @@ The following is a list of requests that are pending your action:
 <!--{include file="site_elements/generic_dialog.tpl"}-->
 
 <script type="text/javascript" src="js/functions/toggleZoom.js"></script>
+<script type="text/javascript" src="../libs/js/LEAF/sensitiveIndicator.js"></script>
 <script type="text/javascript">
 /* <![CDATA[ */
 function toggleDepVisibilityKeypress(evt, depID) {


### PR DESCRIPTION
Included missing scripts in inbox page.  In addition to it missing the `gridInput.js` file, it was missing the `sensitiveIndicator.js` file, causing sensitive data to not toggle.