### PR TITLE
Fix bug with json response from websocket

### DIFF
--- a/servlets/digital-signing/build.gradle
+++ b/servlets/digital-signing/build.gradle
@@ -24,6 +24,7 @@ configurations {
 dependencies {
     compile 'io.vertx:vertx-core:3.3.3'
     compile 'io.vertx:vertx-web:3.3.3'
+    compile 'javax.xml.bind:jaxb-api:2.3.0'
 }
 
 shadowJar.archiveName = 'Sign.jar'

--- a/servlets/digital-signing/src/main/java/leaf/Application.java
+++ b/servlets/digital-signing/src/main/java/leaf/Application.java
@@ -6,6 +6,7 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.JksOptions;
@@ -16,6 +17,8 @@ import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 public class Application extends AbstractVerticle {
 
     private static Logger logger = LoggerFactory.getLogger(Application.class);
+
+    private SignEngine signEngine;
 
     public static void main(String[] args) {
         Runner.run(Application.class);
@@ -41,10 +44,10 @@ public class Application extends AbstractVerticle {
                 logger.info("dataToSign: " + sign.getDataToSign());
                 SignEngine signEngine = new SignEngine();
                 String signature = signEngine.getSignature(sign.getDataToSign());
-                String publicKey = signEngine.getPublicKey().toString();
+                String certificateHex = signEngine.getCertificateHex();
                 String status = (signature.substring(0, 5).equals("ERROR")) ? "ERROR" : "SUCCESS";
                 logger.info("Verified: " + signEngine.verify());
-                ws.write(Buffer.buffer(JsonSerializer.serialize(sign.getKey(), signature, status, publicKey)));
+                ws.write(Buffer.buffer(JsonSerializer.serialize(sign.getKey(), signature, status, certificateHex)));
             });
         });
         router.route("/myapp/*").handler(sockJSHandler);
@@ -57,10 +60,10 @@ public class Application extends AbstractVerticle {
                 logger.info("dataToSign: " + sign.getDataToSign());
                 SignEngine signEngine = new SignEngine();
                 String signature = signEngine.getSignature(sign.getDataToSign());
-                String publicKey = signEngine.getPublicKey().toString();
+                String certificateHex = signEngine.getCertificateHex();
                 String status = (signature.substring(0, 5).equals("ERROR")) ? "ERROR" : "SUCCESS";
                 logger.info("Verified: " + signEngine.verify());
-                ws.writeFinalTextFrame(JsonSerializer.serialize(sign.getKey(), signature, status, publicKey));
+                ws.writeFinalTextFrame(JsonSerializer.serialize(sign.getKey(), signature, status, certificateHex));
             });
         }).listen(8080);
         logger.info("Websocket server started on port 8080");

--- a/servlets/digital-signing/src/main/java/leaf/JsonSerializer.java
+++ b/servlets/digital-signing/src/main/java/leaf/JsonSerializer.java
@@ -11,7 +11,7 @@ public class JsonSerializer {
          return "{\"key\":\"" + key
                  + "\",\"message\":\"" + message
                  + "\",\"status\":\"" + status
-                 + "\",\"publicKey\":\"" + publicKey + "}";
+                 + "\",\"publicKey\":\"" + publicKey + "\"}";
     }
 
     public static Sign deserialize(String json) {

--- a/servlets/digital-signing/src/main/java/leaf/SignEngine.java
+++ b/servlets/digital-signing/src/main/java/leaf/SignEngine.java
@@ -3,11 +3,13 @@ package leaf;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
-import javax.swing.*;
+import javax.xml.bind.DatatypeConverter;
+import java.io.ByteArrayInputStream;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.Signature;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 import java.util.Formatter;
@@ -17,7 +19,7 @@ public class SignEngine {
     private static Logger logger = LoggerFactory.getLogger(SignEngine.class);
     private byte[] signedBytes;
     private String dataToSign;
-    private Certificate publicKey;
+    private String certificateHex;
 
     SignEngine() {}
 
@@ -36,17 +38,19 @@ public class SignEngine {
                     if ((keyUsage[0] && keyUsage[1]) || element.contains("Digital Signature")) alias = element;
                 }
             }
-            logger.info("Using alias \"" + alias + "\"");
             PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, null);
-            publicKey = keyStore.getCertificate(alias);
+            Certificate certificate = keyStore.getCertificate(alias);
+            Formatter certificateFormatter = new Formatter();
+            for (byte b : certificate.getEncoded()) certificateFormatter.format("%02x", b);
+            certificateHex = certificateFormatter.toString();
             Signature signature = Signature.getInstance("SHA256withRSA", "SunMSCAPI");
             signature.initSign(privateKey);
             byte[] dataBytes = dataToSign.getBytes();
             signature.update(dataBytes);
             signedBytes = signature.sign();
-            Formatter formatter = new Formatter();
-            for (byte b : signedBytes) formatter.format("%02x", b);
-            return formatter.toString();
+            Formatter signatureFormatter = new Formatter();
+            for (byte b : signedBytes) signatureFormatter.format("%02x", b);
+            return signatureFormatter.toString();
         } catch (Exception e) {
             logger.error(e.getLocalizedMessage());
             return "ERROR: " + e.getMessage();
@@ -56,7 +60,9 @@ public class SignEngine {
     boolean verify() {
         try {
             Signature signature = Signature.getInstance("SHA256withRSA", "SunMSCAPI");
-            signature.initVerify(publicKey);
+            byte[] certificateBytes = DatatypeConverter.parseHexBinary(certificateHex);
+            Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(new ByteArrayInputStream(certificateBytes));
+            signature.initVerify(certificate);
             signature.update(dataToSign.getBytes());
             return signature.verify(signedBytes);
         } catch (Exception e) {
@@ -65,16 +71,6 @@ public class SignEngine {
         return false;
     }
 
-    Certificate getPublicKey() {
-        return publicKey;
-    }
-
-    byte[] getSignedBytes() { return getSignedBytes(); }
-
-    String getDataToSign() { return dataToSign; }
-
-    static void showErrorMessage(String message) {
-        JOptionPane.showMessageDialog(null, message, "ERROR", JOptionPane.ERROR_MESSAGE);
-    }
+    String getCertificateHex() { return certificateHex; }
 
 }


### PR DESCRIPTION
Added closing quote to public key field for valid json response, syntax tested with jsonlint.com

Certificate is encoded as hex string in response.  Method verify() in SignEngine.java creates a certificate from that hex string and verifies the validity of the signature