### PR TITLE
LEAF 1070: Email Encoding Fix

### DIFF
--- a/LEAF_Request_Portal/Email.php
+++ b/LEAF_Request_Portal/Email.php
@@ -152,10 +152,10 @@ class Email
                 $this->addBCC($recipient);
             }
         }
-        $email['recipient'] = $this->emailRecipient;
+        $email['recipient'] = html_entity_decode($this->emailRecipient, ENT_QUOTES);
         $email['subject'] = $this->emailSubject;
         $email['body'] = $this->emailBody;
-        $email['headers'] = $this->getHeaders();
+        $email['headers'] = html_entity_decode($this->getHeaders(), ENT_QUOTES);
 
         $emailCache = serialize($email);
         $emailQueueName = sha1($emailCache . random_int(0, 99999999));


### PR DESCRIPTION
Fix for THD#237.  Used html_entity_decode() to allow emails with apostrophes.