### PR TITLE
set up guardrails

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -88,7 +88,9 @@ function editProperties(isSubForm) {
                     var buffer = '<select id="workflowID">';
                     buffer += '<option value="0">No Workflow</option>';
                     for(var i in res) {
-                        buffer += '<option value="'+ res[i].workflowID +'">'+ res[i].description +' (ID: #'+ res[i].workflowID +')</option>';
+                        if(res[i].workflowID > 0) {
+                            buffer += '<option value="'+ res[i].workflowID +'">'+ res[i].description +' (ID: #'+ res[i].workflowID +')</option>';
+                        }
                     }
                     buffer += '</select>';
                     $('#container_workflowID').html(buffer);

--- a/LEAF_Request_Portal/sources/FormEditor.php
+++ b/LEAF_Request_Portal/sources/FormEditor.php
@@ -288,6 +288,11 @@ class FormEditor
 
     public function setFormWorkflow($categoryID, $input)
     {
+        // don't allow standardized workflows to be set by the user
+        if($input < 0) {
+            return false;
+        }
+
         // don't allow a workflow to be set if it's a stapled form
         $vars = array(':categoryID' => $categoryID);
         $res = $this->db->prepared_query('SELECT * FROM category_staples


### PR DESCRIPTION
users should only be able to associate forms with their own workflows