### PR TITLE
Leaf1207 textwrap in pdf

### DIFF
--- a/LEAF_Request_Portal/js/formPrint.js
+++ b/LEAF_Request_Portal/js/formPrint.js
@@ -416,11 +416,8 @@ var printer = function() {
                             if (sizeOfBox > maxWidth && maxWidth !== 190) {
                                 subNewRow();
                             }
-                            checkBoxShift = 0;
-                            $.each(indicator.options, function () {
-                                checkBoxShift = this.length > checkBoxShift ? this.length : checkBoxShift;
-                            });
-                            checkBoxShift = checkBoxShift * 5 > 20 ? checkBoxShift * 5 : 20;
+                            doc.setFont("times");
+                            
                             verticalStart = verticalShift;
                             if (title.length > 100) {
                                 splitTitle = doc.splitTextToSize(title, 185);
@@ -432,6 +429,11 @@ var printer = function() {
                                 doc.text(title, horizontalShift + 1, verticalShift + 3);
                             }
                             doc.setFontSize(12);
+                            checkBoxShift = 0;
+                            $.each(indicator.options, function () {
+                                checkBoxShift = doc.getTextWidth(this) + 10 > checkBoxShift ? doc.getTextWidth(this) + 10 : checkBoxShift;
+                            });
+                            checkBoxShift = checkBoxShift > 20 ? checkBoxShift : 20;
                             if (maxWidth > 190) {
                                 horizontalShift = 15;
                             } else {
@@ -439,6 +441,10 @@ var printer = function() {
                             }
                             horizontalShift += 5;
                             for (var i = 0; i < indicator.options.length; i++) {
+                                if ( (horizontalShift + doc.getTextWidth(indicator.options[i])) > maxWidth) {
+                                    verticalShift += 8;
+                                    horizontalShift = 15;
+                                }
                                 if (verticalShift >= height - 40) {
                                     doc.rect(10, verticalStart, 190, height - 20 - verticalStart);
                                     pageFooter(false);

--- a/LEAF_Request_Portal/js/formPrint.js
+++ b/LEAF_Request_Portal/js/formPrint.js
@@ -648,18 +648,18 @@ var printer = function() {
                                 doc.rect(10, verticalShift, 190, 8, 'FD');
                                 doc.text(title, 11, verticalShift + 6);
                             }
+                            doc.setFont("times");
                             checkBoxShift = 0;
                             $.each(indicator.options, function () {
-                                checkBoxShift = this.length > checkBoxShift ? this.length : checkBoxShift;
+                                checkBoxShift = doc.getTextWidth(this) + 10 > checkBoxShift ? doc.getTextWidth(this) + 10 : checkBoxShift;
                             });
-                            checkBoxShift = checkBoxShift * 5 > 20 ? checkBoxShift * 5 : 20;
+                            checkBoxShift = checkBoxShift > 20 ? checkBoxShift : 20;
                             horizontalShift = 20;
                             verticalStart = verticalShift;
                             doc.setTextColor(0);
-                            doc.setFont("times");
                             verticalShift += 4;
                             for (var i = 0; i < indicator.options.length; i++) {
-                                if (horizontalShift > maxWidth) {
+                                if ( (horizontalShift + doc.getTextWidth(indicator.options[i])) > maxWidth) {
                                     verticalShift += 8;
                                     horizontalShift = 20;
                                 }

--- a/LEAF_Request_Portal/js/formPrint.js
+++ b/LEAF_Request_Portal/js/formPrint.js
@@ -375,7 +375,16 @@ var printer = function() {
                                         fitSize = (splitText.length - i) * lineSpacing;
                                         doc.setFontSize(8);
                                         doc.setFont("helvetica");
-                                        doc.text(titleContinued, 11, verticalShift + 3);
+                                        if (titleContinued.length > 190) {
+                                            splitTitleContinued = doc.splitTextToSize(titleContinued, 185);
+                                            for (var i = 0; i < splitTitleContinued.length; i++) {
+                                                verticalShift += 3;
+                                                doc.text(splitTitleContinued[i], 11, verticalShift);
+                                            }
+                                            verticalShift += 4;
+                                        } else {
+                                            doc.text(titleContinued, 11, verticalShift + 3);
+                                        }
                                         doc.setFontSize(12);
                                         doc.setFont("times");
                                     }
@@ -439,7 +448,16 @@ var printer = function() {
                                     fitSize = (splitText.length - i) * lineSpacing;
                                     doc.setFontSize(8);
                                     doc.setFont("helvetica");
-                                    doc.text(titleContinued, 11, verticalShift + 3);
+                                    if (titleContinued.length > 190) {
+                                        splitTitleContinued = doc.splitTextToSize(titleContinued, 185);
+                                        for (var i = 0; i < splitTitleContinued.length; i++) {
+                                            verticalShift += 3;
+                                            doc.text(splitTitleContinued[i], 11, verticalShift);
+                                        }
+                                        verticalShift += 4;
+                                    } else {
+                                        doc.text(titleContinued, 11, verticalShift + 3);
+                                    }
                                     doc.setFontSize(12);
                                     doc.setFont("times");
                                 }
@@ -578,7 +596,16 @@ var printer = function() {
                                         verticalStart = 10;
                                         fitSize = (splitText.length - i) * lineSpacing;
                                         doc.rect(10, verticalShift, 190, 8, 'FD');
-                                        doc.text(titleContinued, 11, verticalShift + 6);
+                                        if (titleContinued.length > 190) {
+                                            splitTitleContinued = doc.splitTextToSize(titleContinued, 185);
+                                            for (var i = 0; i < splitTitleContinued.length; i++) {
+                                                verticalShift += 3;
+                                                doc.text(splitTitleContinued[i], 11, verticalShift);
+                                            }
+                                            verticalShift += 4;
+                                        } else {
+                                            doc.text(titleContinued, 11, verticalShift + 6);
+                                        }
                                         doc.setFont("times");
                                     }
                                     doc.setTextColor(0);


### PR DESCRIPTION
**First case**
Create an indicator with multiple checkboxes. Set the options to:
```
Concur with decision.
Do not Concur with decision.
```

This should make the text overflow.

**Second case**
Create an indicator with a very long title and make sure the box lands at the bottom of a PDF page, so that it continues onto the next page. The title will repeat and should overflow. Set title to:
```
Travel to a particular site in order to perform operational or managerial activities. Travel to attend a meeting to discuss general agency operations, review status reports or discuss topics of general interest. Examples: Employee's day-to-day operational or managerial activities, as defined by the agency, to include, but not be limited to: hearings, site visit, information meeting, inspections, audits, investigations and examinations. 
```