### PR TITLE
LEAF-1301 Adding FakeSMTP to docker stack

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,6 +45,28 @@ services:
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_ALLOW_EMPTY_PASSWORD=${MYSQL_ALLOW_EMPTY_PASSWORD}
 
+  smtp:
+    image: kurzdigital/fake-smtp # https://hub.docker.com/r/kurzdigital/fake-smtp/
+    expose:
+      - '2525'
+    ports:
+      - "2525:25" # smtp port
+      - "5080:5080" # web ui port
+    restart: 'always'
+    networks:
+      code-network:
+        aliases:
+          - smtp
+
+    environment:
+      - "SMTP_PORT=25"
+      - "APP_USER=tester" # ui login
+      - "APP_PASSWORD=tester"
+      - "MYSQL_USER=tester"
+      - "MYSQL_PASSWORD=tester"
+
+
+
 volumes:
   leaf-mysql-data:
   leaf-php-data:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -18,6 +18,15 @@ RUN composer global require robmorgan/phinx ^0.9.2
 EXPOSE 80
 EXPOSE 443
 
+# Mail()
+RUN apt-get install -y ssmtp && \
+  apt-get clean && \
+  echo "FromLineOverride=YES" >> /etc/ssmtp/ssmtp.conf && \
+  echo 'sendmail_path = "/usr/sbin/ssmtp -t"' > /usr/local/etc/php/conf.d/mail.ini
+# mv php.ini and replace log dir
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+COPY /docker/php/ssmtp/ssmtp.conf /etc/ssmtp/
 COPY /docker/php/000-default.conf /etc/apache2/sites-enabled/
 COPY /docker/php/default-ssl.conf /etc/apache2/sites-enabled/
 COPY /docker/php/apache2.conf /etc/apache2/

--- a/docker/php/ssmtp/ssmtp.conf
+++ b/docker/php/ssmtp/ssmtp.conf
@@ -1,0 +1,4 @@
+root=LEAF-noreply
+hostname=localhost
+mailhub=smtp
+FromLineOverride=YES

--- a/test/LEAF_Request_Portal_Tests/tests/api/MailTest.php
+++ b/test/LEAF_Request_Portal_Tests/tests/api/MailTest.php
@@ -1,0 +1,10 @@
+<?php
+// the message
+$msg = "First line of text\nSecond line of text";
+
+// use wordwrap() if lines are longer than 70 characters
+$msg = wordwrap($msg,70);
+
+// send email
+mail("no@email.com","My subject",$msg);
+?>


### PR DESCRIPTION
LEAF-1301 Adding FakeSMTP to docker stack

Adds FakeSMTP and configures php for use.

FakeSMTP web portal: http://localhost:5080/email

user: tester
pass: tester