### PR TITLE
hotfix/admin-workflow-action-access

### DIFF
--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -169,7 +169,7 @@ class FormWorkflow
                 }
 
                 // dependencyID -2 is for requestor followup
-                if ($res[$i]['dependencyID'] == -2)
+                if ($res[$i]['dependencyID'] == -2 && !$res[$i]['hasAccess'])
                 {
                     $hasAccess = $res[$i]['userID'] == $this->login->getUserID();
 


### PR DESCRIPTION
This resolves an access issue where admins can't apply actions when a request has been sent to "requestor followup"