### PR TITLE
feature/more-efficient-queries

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1841,11 +1841,13 @@ class Form
                 }
 
                 // grants backups the ability to access records of their backupFor
-                foreach ($this->employee->getBackupsFor($this->login->getEmpUID()) as $emp)
-                {
-                    if ($dep['userID'] == $emp["userName"])
+                if($temp[$dep['recordID']] == 0) {
+                    foreach ($this->employee->getBackupsFor($this->login->getEmpUID()) as $emp)
                     {
-                        $temp[$dep['recordID']] = 1;
+                        if ($dep['userID'] == $emp["userName"])
+                        {
+                            $temp[$dep['recordID']] = 1;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Avoids calling getBackupsFor() if the current user already has access, which prevents unnecessary DB queries.