### PR TITLE
feature/query-data-filter

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2439,6 +2439,47 @@ class Form
         return 1;
     }
 
+    /**
+     * filterData is an experimental output filter used to lower data transfer to clients.
+     * $_GET['x-filterData'] is a CSV of desired array keys. All other keys will be filtered out.
+     * id_timestamp is a special key to signal a need for s1.id##_timestamp values
+     * The experimental parameter x-filterData is subject to change and use of this
+     * should be limited.
+     */
+    private function filterData($data) {
+        if(isset($_GET['x-filterData'])) {
+            $filter = explode(',', $_GET['x-filterData'], 32);
+            $filter = array_flip($filter);
+            // add s1 data fields
+            $filter['s1'] = 1;
+
+            // iterate through each record
+            foreach($data as $key => $value) {
+                $ids = array_keys($value);
+                // iterate through keys within each record
+                foreach($ids as $id) {
+                    if(!isset($filter[$id])) {
+                        unset($data[$key][$id]);
+                    }
+
+                    // filter out s1 timestamps if applicable
+                    if(isset($data[$key]['s1'])
+                        && !isset($filter['id_timestamp'])
+                    ) {
+                        // iterate through keys within each s1 set
+                        foreach($data[$key]['s1'] as $sKey => $sValue) {
+                            if(strpos($sKey, '_timestamp') !== false) {
+                                unset($data[$key]['s1'][$sKey]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $data;
+    }
+
     public function query($inQuery)
     {
         $query = json_decode(html_entity_decode(html_entity_decode($inQuery)), true);
@@ -3051,7 +3092,8 @@ class Form
                 $indicatorIDs .= $indicatorID . ',';
             }
 
-            return $this->getCustomData($data, $indicatorIDs);
+            $data = $this->getCustomData($data, $indicatorIDs);
+            return $this->filterData($data);
         }
 
         return $data;

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2466,8 +2466,9 @@ class Form
                     if(isset($data[$key]['s1'])
                         && !isset($filter['id_timestamp'])
                     ) {
+                        $sids = array_keys($data[$key]['s1']);
                         // iterate through keys within each s1 set
-                        foreach($data[$key]['s1'] as $sKey => $sValue) {
+                        foreach($sids as $sKey) {
                             if(strpos($sKey, '_timestamp') !== false) {
                                 unset($data[$key]['s1'][$sKey]);
                             }

--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -7,7 +7,8 @@ var LeafFormQuery = function() {
 	var query = {};
 	var successCallback = null;
 	var rootURL = '';
-	var useJSONP = false;
+    var useJSONP = false;
+    var extraParams = '';
 
 	clearTerms();
 
@@ -182,6 +183,14 @@ var LeafFormQuery = function() {
     }
 
     /**
+     * Add extra parameters to the end of the query API URL
+     * @param string params
+     */
+    function setExtraParams(params) {
+        extraParams = params;
+    }
+
+    /**
      * @param funct - Success callback (see format for jquery ajax success)
      * @memberOf LeafFormQuery
      */
@@ -203,7 +212,7 @@ var LeafFormQuery = function() {
     	if(useJSONP == false) {
         	return $.ajax({
         		type: 'GET',
-        		url: rootURL + 'api/?a=form/query&q=' + JSON.stringify(query),
+        		url: rootURL + 'api/?a=form/query&q=' + JSON.stringify(query) + extraParams,
         		dataType: 'json',
         		success: successCallback,
         		cache: false
@@ -212,7 +221,7 @@ var LeafFormQuery = function() {
     	else {
         	return $.ajax({
         		type: 'GET',
-        		url: rootURL + 'api/?a=form/query&q=' + JSON.stringify(query) + '&format=jsonp',
+        		url: rootURL + 'api/?a=form/query&q=' + JSON.stringify(query) + '&format=jsonp' + extraParams,
         		dataType: 'jsonp',
         		success: successCallback,
         		cache: false
@@ -234,7 +243,8 @@ var LeafFormQuery = function() {
 		setLimitOffset: setLimitOffset,
 		setRootURL: function(url) { rootURL = url; },
 		getRootURL: function() { return rootURL; },
-		useJSONP: function(state) { useJSONP = state; },
+        useJSONP: function(state) { useJSONP = state; },
+        setExtraParams: setExtraParams,
 		join: join,
 		sort: sort,
 		onSuccess: onSuccess,


### PR DESCRIPTION
Queries returned by formQuery are often overly verbose. This adds an experimental option to significantly decrease total data transfer size and time by only sending requested data to clients.