### PR TITLE
Commiting CODEOWNERS file to repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @mgaoVA @dastan-rahimi @jeremyrl @thomasnguyen95 @g-theriot @abiola-adewuyi @cameron-chilton @dogwang94 @patrickcgs
+


### PR DESCRIPTION
CODEOWNERS file is used by github when Pull Requests are created to:

1) email owners with link to PR
2) automatically request reviewers

