### PR TITLE
LEAF-1571: merged fpr

### DIFF
--- a/Jenkinsfile.dev
+++ b/Jenkinsfile.dev
@@ -32,6 +32,16 @@ pipeline {
         stage('fortify') {
             steps {
                 script {
+
+                    annotated_fprs = s3FindFiles(bucket: 'leaf-pipeline', onlyFiles: true, path: 'fortify/annotated', glob: '*.fpr')
+                    if( annotated_fprs ) {
+                        println("Found annotated fprs: ${annotated_fprs}")
+                        def annotated_fpr = annotated_fprs[0]
+                        println("Using annotated fpr for annotations: ${annotated_fpr}")
+                        s3Download bucket: 'leaf-pipeline', file: "fort_report/leaf_orig.fpr", path: "fortify/annotated/${annotated_fpr}", force:true
+                    }
+
+
                     sh 'pwd'
                     sh 'ls'
                     sh 'ls fort_report/'

--- a/fort_report/FortifyReportGen.sh
+++ b/fort_report/FortifyReportGen.sh
@@ -16,6 +16,8 @@ BUILD_NUMBER="1"
 FILE_PREFIX="leaf"
 ARTIFACT_ID="${FILE_PREFIX}"
 FPR="$PWD/fort_report/${FILE_PREFIX}.fpr"
+FPR_ORIG="$PWD/fort_report/${FILE_PREFIX}_orig.fpr"
+FPR_MERGED="$PWD/fort_report/${FILE_PREFIX}_merged.fpr"
 PDF="$PWD/fort_report/${FILE_PREFIX}.pdf"
 PROPERTIES_FILE="$PWD/fort_report/fortify.properties"
 
@@ -46,7 +48,20 @@ echo --------------------------------------
 echo Starting scan
 sourceanalyzer $MEMORY $LAUNCHERSWITCHES -b $ARTIFACT_ID -build-label $ARTIFACT_ID -scan -f $FPR -verbose
 
+if [ -f $FPR_ORIG ]; then
+echo --------------------------------------
+echo Merging FPR...
+FPRUtility -merge -project $FPR_ORIG -source $FPR -f $FPR_MERGED
+fi
+
 echo --------------------------------------
 echo -e "\nGenerating PDF report...";
-ReportGenerator -format pdf -f $PDF -source "${FPR}" -template $TEMPLATE $REPORT_OPTIONS
+if [ -f $FPR_MERGED ]; then
+        export FPR_SRC="$FPR_MERGED"
+else
+        export FPR_SRC="$FPR"
+fi
+
+ReportGenerator -format pdf -f $PDF -source "${FPR_SRC}" -template $TEMPLATE $REPORT_OPTIONS || true;
+
 


### PR DESCRIPTION
LEAF-1571: merged fpr

Adding support for merging annotations during pipeline execution of fortify.

Fortify annnotations are a cumbersome process required by the developer to mark
findings that are in dispute, such as false findings.

Uploaded annotated FPR file to the pipeline bucket/annotated/ folder.

Ensure only a single FPR is in that directory, the pipeline script will use the first one found.