### PR TITLE
hotfix/admin_visibility

### DIFF
--- a/LEAF_Request_Portal/Email.php
+++ b/LEAF_Request_Portal/Email.php
@@ -124,21 +124,17 @@ class Email
 
     public function addGroupRecipient($groupID)
     {
-        if ($this->orgchartInitialized == false)
-        {
-            $this->initOrgchart();
-        }
-        $positions = $this->group->listGroupPositions($groupID);
-        foreach ($positions as $pos)
-        {
-            $this->addPositionRecipient($pos['positionID']);
-        }
+        require_once 'VAMC_Directory.php';
+        $dir = new VAMC_Directory;
 
-        $employees = $this->group->listGroupEmployees($groupID);
-        foreach ($employees as $emp)
-        {
-            $res = $this->employee->getAllData($emp['empUID'], 6);
-            $this->addRecipient($res[6]['data']);
+        $res = $this->portal_db->prepared_query("SELECT `userID`
+                                                 FROM `users` 
+                                                 WHERE groupID=:groupID
+                                                    AND active=1", 
+                                                array(':groupID' => $groupID));
+        foreach($res as $user) {
+            $tmp = $dir->lookupLogin($user['userID']);
+            $email->addRecipient($tmp[0]['Email']);
         }
     }
 

--- a/LEAF_Request_Portal/Login.php
+++ b/LEAF_Request_Portal/Login.php
@@ -262,7 +262,8 @@ class Login
         if (!isset($this->cache['checkGroup']))
         {
             $var = array(':userID' => $this->userID);
-            $result = $this->userDB->prepared_query('SELECT * FROM users WHERE userID=:userID', $var);
+            $result = $this->userDB->prepared_query('SELECT * FROM users WHERE userID=:userID
+                                                        AND active=1', $var);
 
             foreach ($result as $group)
             {

--- a/LEAF_Request_Portal/admin/Group.php
+++ b/LEAF_Request_Portal/admin/Group.php
@@ -127,7 +127,8 @@ class Group
                           ':groupID' => $groupID, );
             $res = $this->db->prepared_query('SELECT * FROM users WHERE userID=:userID AND groupID=:groupID', $vars);
 
-            if ($res[0]['locallyManaged'] == 1)
+            if ($res[0]['locallyManaged'] == 1
+                || $groupID == 1)
             {
                 $res = $this->db->prepared_query('DELETE FROM users WHERE userID=:userID AND groupID=:groupID', $vars);
             }

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -81,7 +81,8 @@ function getPrimaryAdmin() {
 function populateMembers(groupID, members) {
     $('#members' + groupID).html('');
     for(var i in members) {
-        if(members[i].active == 1){
+        if(members[i].active == 1
+            || groupID == 1) {
             $('#members' + groupID).append(members[i].Lname + ', ' + members[i].Fname + '<br />');
         }
     }


### PR DESCRIPTION
This prevents admins from being hidden on the UAG overview page instead of being removed, and enforces group access rules with the new users.active column.

Additionally emails sent to groups use the new users.active column.