### PR TITLE
Bugfix/LEAF-1633: Form Editor Workflow Titles Overflow Containers

### DIFF
--- a/LEAF_Request_Portal/admin/css/mod_form.css
+++ b/LEAF_Request_Portal/admin/css/mod_form.css
@@ -12,27 +12,30 @@
 
 .formPreviewTitle {
     font-weight: bold;
-    padding-bottom: 1em;
-    padding: 8px;
+    padding: 0.4rem;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
 }
 
 .formPreviewDescription {
-    padding-bottom: 1em;
-    padding: 8px;
+    padding: 0.2rem 0.4rem 0.2rem 0.4em;
     overflow: hidden;
     white-space: normal;
     text-overflow: ellipsis;
-    height: 5.3rem;
+    height: 4.7rem;
     font-size: 0.9rem;
     line-height: 1.2rem;
 }
 
 .formPreviewStatus {
-    padding: 8px;
+    padding: 0.2rem 0.4rem 0.2rem 0.4rem;
+    font-size: 0.6rem;
     color: red;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    margin-top: 0.3rem;
 }
 
 .formPreviewWorkflow {

--- a/LEAF_Request_Portal/admin/css/mod_form.css
+++ b/LEAF_Request_Portal/admin/css/mod_form.css
@@ -35,6 +35,11 @@
     background-color: #c9ddff;
     width: 100%;
     text-align: center;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
 }
 
 .formPreview:hover {

--- a/LEAF_Request_Portal/admin/css/mod_form.css
+++ b/LEAF_Request_Portal/admin/css/mod_form.css
@@ -14,14 +14,20 @@
     font-weight: bold;
     padding-bottom: 1em;
     padding: 8px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 .formPreviewDescription {
     padding-bottom: 1em;
     padding: 8px;
-    text-overflow: ellipsis;
     overflow: hidden;
-    white-space: nowrap;
+    white-space: normal;
+    text-overflow: ellipsis;
+    height: 5.3rem;
+    font-size: 0.9rem;
+    line-height: 1.2rem;
 }
 
 .formPreviewStatus {
@@ -34,10 +40,10 @@
     bottom: 0;
     background-color: #c9ddff;
     width: 100%;
-    text-align: center;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+    padding: 0.3rem;
 }
 
 }

--- a/LEAF_Request_Portal/admin/css/style.css
+++ b/LEAF_Request_Portal/admin/css/style.css
@@ -648,6 +648,9 @@ span.browsetypes {
     padding: 4px;
     border: 1px solid black;
     cursor: pointer;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 .buttonNorm:hover, .buttonNormSelected, .buttonNorm:hover>span, .buttonNorm:focus {


### PR DESCRIPTION
Testing discovered that long workflow titles go outside the borders of the form container. Added CSS props to hide overflow text in Form Editor homescreen.

- added props to .formPreviewWorkflow in mod_form.css

Before: 
<img width="906" alt="Screen Shot 2020-08-10 at 3 45 58 PM" src="https://user-images.githubusercontent.com/2892376/89824128-a14f8100-db20-11ea-8938-89755343b145.png">

After:
<img width="765" alt="Screen Shot 2020-08-10 at 3 41 27 PM" src="https://user-images.githubusercontent.com/2892376/89824153-aad8e900-db20-11ea-9791-116a99d17907.png">



