### PR TITLE
bugfix/LEAF-1763: Put Site Settings Buttons Back As Links

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_system.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_system.tpl
@@ -189,11 +189,11 @@ function renderSettings(res) {
                 query.addTerm('stepID', '!=', 'resolved');
                 query.onSuccess(function(data) {
                     if(data.length == 0) {
-                        $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: red; color: white; font-weight: bold">Not Certified</span> <button class="usa-button usa-button--accent-cool leaf-btn-med" href="../report.php?a=LEAF_start_leaf_secure_certification">Start Certification Process</button>');
+                        $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: red; color: white; font-weight: bold">Not Certified</span> <a class="buttonNorm" href="../report.php?a=LEAF_start_leaf_secure_certification">Start Certification Process</a>');
                     }
                     else {
                         var recordID = data[Object.keys(data)[0]].recordID;
-                        $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: red; color: white; font-weight: bold">Not Certified</span> <button class="usa-button usa-button--accent-cool leaf-btn-med" href="../index.php?a=printview&recordID='+ recordID +'">Check Certification Progress</button>');
+                        $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: red; color: white; font-weight: bold">Not Certified</span> <a class="buttonNorm" href="../index.php?a=printview&recordID='+ recordID +'">Check Certification Progress</a>');
                     }
                 });
                 query.execute();

--- a/LEAF_Request_Portal/admin/templates/mod_system.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_system.tpl
@@ -181,7 +181,7 @@ function renderSettings(res) {
                             mostRecentID = i;
                         }
                     }
-                    $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: green; color: white; font-weight: bold">Certified</span> <button class="usa-button usa-button--accent-cool leaf-btn-med" href="../index.php?a=printview&recordID='+ mostRecentID +'">View Details</button>');
+                    $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: green; color: white; font-weight: bold">Certified</span> <a class="buttonNorm" href="../index.php?a=printview&recordID='+ mostRecentID +'">View details</a>');
                 });
                 query.execute();
             }


### PR DESCRIPTION
The 'Start Certification Process' button and it's sibling were not working because they were put in button tags with an href. This PR puts them back as they currently exist in master branch.