### PR TITLE
fix/save-racecondition

### DIFF
--- a/LEAF_Request_Portal/js/dialogController.js
+++ b/LEAF_Request_Portal/js/dialogController.js
@@ -73,11 +73,13 @@ dialogController.prototype.setContent = function(content) {
 };
 
 dialogController.prototype.indicateBusy = function() {
-	$('#' + this.indicatorID).css('visibility', 'visible');
+    $('#' + this.indicatorID).css('visibility', 'visible');
+    $('#' + this.btnSaveID).css('visibility', 'hidden');
 };
 
 dialogController.prototype.indicateIdle = function() {
-	$('#' + this.indicatorID).css('visibility', 'hidden');
+    $('#' + this.indicatorID).css('visibility', 'hidden');
+    $('#' + this.btnSaveID).css('visibility', 'visible');
 };
 
 dialogController.prototype.enableLiveValidation = function() {


### PR DESCRIPTION
Prevent potential race condition for xhr-populated forms.

Before this patch, it's possible to click on Save before a form has been populated, which causes blank data to be sent to the server.