### PR TITLE
bugfix/LEAF-1758: LEAF Library Forms Table Pushed Below Left Nav

### DIFF
--- a/LEAF_Request_Portal/admin/templates/view_form_library.tpl
+++ b/LEAF_Request_Portal/admin/templates/view_form_library.tpl
@@ -154,6 +154,7 @@ $(function() {
 </script>
 
 <div class="leaf-center-content">
+
     <h2>LEAF Library</h2>
     <div id="menu" style="float: left; width: 230px">
         <span style="position: absolute; color: transparent" aria-atomic="true" aria-live="assertive" id="filterStatus" role="status"></span>
@@ -168,7 +169,7 @@ $(function() {
         <div role="button" onkeydown="triggerKeydown(event, this)" class="buttonNorm leaf-marginBot-1rem" tabindex="0" onclick="applyFilter('Logistics')" style="width: 220px"><img aria-hidden="true" src="../../libs/dynicons/?img=package-x-generic.svg&amp;w=32" alt="Icon" title="Icon" /> Logistics</div>
         <div role="button" onkeydown="triggerKeydown(event, this)" class="buttonNorm leaf-marginBot-1rem" tabindex="0" onclick="applyFilter('Fiscal')" style="width: 220px"><img aria-hidden="true" src="../../libs/dynicons/?img=x-office-spreadsheet.svg&amp;w=32" alt="Icon" title="Icon" /> Fiscal</div>
     </div>
-    <div id="formEditor_content" style="margin-left: 184px; padding-left: 8px">
+    <div id="formEditor_content" style="margin-left: 238px; padding-left: 8px">
 
         <div class="leaf-marginBot-halfRem leaf-bold">Search Form Library:</div>
         <div id="searchContainer"></div>


### PR DESCRIPTION
The Forms Library page results container is being pushed below the left side nav because it does not have enough margin to clear the left menu. No screenshot because there is no form library data in local environment.

- Added margin to main left container so forms table is not pushed down.