### PR TITLE
bugfix/LEAF-1762: Email Template Editor Link Missing from Admin UI Global Nav

### DIFF
--- a/LEAF_Request_Portal/admin/templates/menu.tpl
+++ b/LEAF_Request_Portal/admin/templates/menu.tpl
@@ -64,6 +64,7 @@
                 <ul>
                     <li><a href="?a=mod_templates">Template Editor</a></li>
                     <li><a href="?a=mod_templates_reports">LEAF Programmer</a></li>
+                    <li><a href="?a=mod_templates_email">Email Template Editor</a></li>
                     <li><a href="?a=mod_file_manager">File Manager</a></li>
                     <li><a href="../?a=search">Search Database</a></li>
                     <li><a href="?a=admin_sync_services">Sync Services</a></li>


### PR DESCRIPTION
- Added email template editor link to global nav for Admin UI
- Tested locally and link is correct

![Screen Shot 2020-08-24 at 12 57 59 PM](https://user-images.githubusercontent.com/2892376/91073918-cc020500-e609-11ea-9e3c-792358c2b441.png)
