### PR TITLE
bugfix/LEAF-1786: Template Editor Save/Restore Original Button Behavior

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_templates.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates.tpl
@@ -27,13 +27,13 @@
 
         <aside class="sidenav-right">
 
-            <div id="controls">
+            <div id="controls" style="visibility: hidden">
                 
                 <button class="usa-button leaf-display-block leaf-btn-med leaf-width-11rem" onclick="save();">
                     Save Changes<span id="saveStatus" class="leaf-display-block leaf-font-normal leaf-font0-5rem"></span>
                 </button>
                 
-                <button class="usa-button usa-button--secondary leaf-marginTop-1rem leaf-display-block leaf-btn-med leaf-width-11rem" onclick="restore();">
+                <button class="usa-button usa-button--secondary leaf-marginTop-1rem leaf-display-block leaf-btn-med leaf-width-11rem  modifiedTemplate" onclick="restore();">
                     Restore Original
                 </button>
                 
@@ -41,7 +41,7 @@
                     Stop Comparing
                 </button>
                 
-                <button class="usa-button usa-button--outline leaf-marginTop-1rem leaf-display-block leaf-btn-med leaf-width-11rem" id="btn_compare" onclick="compare();">
+                <button class="usa-button usa-button--outline leaf-marginTop-1rem leaf-display-block leaf-btn-med leaf-width-11rem  modifiedTemplate" id="btn_compare" onclick="compare();">
                     Compare to Original
                 </button>
                 


### PR DESCRIPTION
Restored misplace classes and IDs from older branch. Tested locally and buttons are behaving as expected.

No changes made yet:
![Screen Shot 2020-08-24 at 1 14 27 PM](https://user-images.githubusercontent.com/2892376/91075411-066ca180-e60c-11ea-9f2f-f70745919c0c.png)

Changes made:
![Screen Shot 2020-08-24 at 1 14 50 PM](https://user-images.githubusercontent.com/2892376/91075449-13899080-e60c-11ea-8979-83b7cdda6ac2.png)

