### PR TITLE
bugfix/LEAF-1809: Subordinate Sites - Editor Visibility

### DIFF
--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -492,6 +492,7 @@ $main->assign('login', $t_login->fetch('login.tpl'));
 $t_menu->assign('action', $action);
 $t_menu->assign('orgchartPath', Config::$orgchartPath);
 $t_menu->assign('name', XSSHelpers::sanitizeHTML($login->getName()));
+$t_menu->assign('siteType', XSSHelpers::xscrub($settings['siteType']));
 $o_menu = $t_menu->fetch('menu.tpl');
 $main->assign('menu', $o_menu);
 $tabText = $tabText == '' ? '' : $tabText . '&nbsp;';


### PR DESCRIPTION
**From Jira:**
- _Subordinate sites: Even though the form and workflow editor buttons don’t show up in the Admin Panel, users can still get to them via the Admin dropdown – Form Editor and Workflow Editor are still visible._
- _If the portal type is nationally standardized subordinate, workflow and form editor should not show up in the NAV menu_
- _For subordinate sites: The Form Editor and Workflow editor should not be visible in the admin panel and menu._

**AC:**
- _Workflow and Form editor should not show up in NAV menu if the portal type is set to " nationally standardized subordinate" under site settings_
- _Definition of done: Nationally standardized subordinate should not show Workflow and Form editor under NAV menu_

**In This PR:**
-  **Added 'siteType' variable to t_menu template on index.php**
-  **Tested and working in local env.**

![Screen Shot 2020-09-14 at 10 27 56 AM](https://user-images.githubusercontent.com/2892376/93099557-2117c080-f676-11ea-8822-21da6ee80ff6.png)
![Screen Shot 2020-09-14 at 10 28 08 AM](https://user-images.githubusercontent.com/2892376/93099571-26750b00-f676-11ea-857d-0748adc13daa.png)

