### PR TITLE
bugfix/LEAF-1795-2: Sitemap Fixes from Preprod Testing

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_sitemaps_template.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_sitemaps_template.tpl
@@ -55,6 +55,7 @@
         $.each(buttons, function(index, value){
             addButtonToUI(value);
         });
+        save();
     }
                     
 	// insert button into sortable list and sidenav
@@ -238,7 +239,7 @@
             <button class="usa-button leaf-width-13rem leaf-marginTopBot-halfRem" onclick="createGroup();"><i class="fas fa-plus" title="Delete Card"></i> Add Card</button>
         </div>
         <div>
-            <button class="usa-button usa-button--outline leaf-width-13rem leaf-marginTopBot-halfRem"><a href="./?a=sitemap" target="_blank">View Sitemap</a></button>
+            <a href="./?a=sitemap" target="_blank" class="usa-button usa-button--outline leaf-width-13rem leaf-marginTopBot-halfRem">View Sitemap</a>
         </div>
         
         <!--<div class="leaf-sidenav-bottomBtns">


### PR DESCRIPTION
**Testers found:**

- Bug-When the user is in IE and clicks on the View Sitemap button, the expected behavior is another tab opens and the user can view the sitemap.  Nothing happens when the user clicks on this button.
- Potential issue-The order of the cards in the sitemaps template is not reflected in the sitemap when viewed.  Is this intended behavior? Cameron Chilton call me when you can so we can discuss.

**Fixes in PR:**
- Added save function to refreshButtons
- Changed 'View Sitemap' button to a tag so link works in IE11