### PR TITLE
bugfix/LEAF-1796: Email Template Editor Line Numbers Overlap

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -169,7 +169,12 @@ function addMember(groupID, userID) {
 
 // convert to title case
 function toTitleCase(str) {
-    return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    if (str == "" || str == null) {
+        return;
+    }
+    else {
+        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    }
 }
 
 function addAdmin(userID) {

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -167,14 +167,8 @@ function addMember(groupID, userID) {
     });
 }
 
-// convert to title case
 function toTitleCase(str) {
-    if (str == "" || str == null) {
-        return;
-    }
-    else {
-        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-    }
+    (str == "" || str == null) ? return "" : return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
 }
 
 function addAdmin(userID) {

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -167,8 +167,14 @@ function addMember(groupID, userID) {
     });
 }
 
+// convert to title case
 function toTitleCase(str) {
-    (str == "" || str == null) ? return "" : return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    if (str == "" || str == null) {
+        return "";
+    }
+    else {
+        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    }
 }
 
 function addAdmin(userID) {

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -169,12 +169,7 @@ function addMember(groupID, userID) {
 
 // convert to title case
 function toTitleCase(str) {
-    if (str == "" || str == null) {
-        return "";
-    }
-    else {
-        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-    }
+    return (str == "" || str == null) ? "" : str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
 }
 
 function addAdmin(userID) {

--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -284,7 +284,12 @@ function viewHistory(groupID){
 
 // convert to title case
 function toTitleCase(str) {
-    (str == "" || str == null) ? return "" : return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    if (str == "" || str == null) {
+        return "";
+    }
+    else {
+        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    }
 }
 
 $(function() {

--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -284,12 +284,7 @@ function viewHistory(groupID){
 
 // convert to title case
 function toTitleCase(str) {
-    if (str == "" || str == null) {
-        return "";
-    }
-    else {
-        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-    }
+    return (str == "" || str == null) ? "" : str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
 }
 
 $(function() {

--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -284,7 +284,12 @@ function viewHistory(groupID){
 
 // convert to title case
 function toTitleCase(str) {
-    return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    if (str == "" || str == null) {
+        return;
+    }
+    else {
+        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    }
 }
 
 $(function() {

--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -284,12 +284,7 @@ function viewHistory(groupID){
 
 // convert to title case
 function toTitleCase(str) {
-    if (str == "" || str == null) {
-        return;
-    }
-    else {
-        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-    }
+    (str == "" || str == null) ? return "" : return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
 }
 
 $(function() {

--- a/LEAF_Request_Portal/templates/email/LEAF_main_email_template.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_main_email_template.tpl
@@ -1,6 +1,8 @@
 <html>
 <body style="font-family: verdana; font-size: 12px">
+
 {{$emailBody}}
+
 <br />
 <br />
 --- THIS IS AN AUTOMATED MESSAGE ---


### PR DESCRIPTION
Default email template had unreadable line numbers because of overlap of content and line numbers. Added 2 line breaks to main email template to get around line number overlap.

**Before:**
![Screen Shot 2020-09-24 at 2 21 11 PM](https://user-images.githubusercontent.com/2892376/94184138-74a5bd80-fe71-11ea-8327-898f1d59194f.png)

**After:**
![Screen Shot 2020-09-24 at 2 20 58 PM](https://user-images.githubusercontent.com/2892376/94184157-7cfdf880-fe71-11ea-9ef2-3f8c11827b83.png)
