### PR TITLE
bugfix/LEAF-1811: Fix Restore Fields Table Display Bug in IE

### DIFF
--- a/LEAF_Request_Portal/admin/templates/view_disabled_fields.tpl
+++ b/LEAF_Request_Portal/admin/templates/view_disabled_fields.tpl
@@ -3,7 +3,7 @@
     <h2>List of disabled fields available for recovery</h2>
     <div>Disabled fields and associated data may be permanently deleted after 30 days</div>
 
-    <table class="table">
+    <table class="usa-table">
         <thead>
             <tr>
                 <th>indicatorID</th>


### PR DESCRIPTION
Restore Fields table in IE11 preprod does not have text breaks, causing table data to stretch off to the right. 

PR change is css class of disabled field table so that content will wrap. 

_Tested in local VMbox IE11 and in local dev on developer's machine and testers._

**Before:**
![1811-before](https://user-images.githubusercontent.com/2892376/94486732-d5a0fe80-01ad-11eb-80d9-315d175485b5.png)

**After:**
![1811-after](https://user-images.githubusercontent.com/2892376/94486741-d6d22b80-01ad-11eb-848f-a2864b6f8e85.png)

