### PR TITLE
hotfix/LEAF-1796 Template Editor Line Numbers v2

### DIFF
--- a/LEAF_Request_Portal/templates/email/LEAF_main_email_template.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_main_email_template.tpl
@@ -1,5 +1,5 @@
 <html>
-<body style="font-family: verdana; font-size: 12px">
+<body style="font-family: verdana; font-size: 12px;">
 <br />
 <br />
 {{$emailBody}}

--- a/LEAF_Request_Portal/templates/email/LEAF_main_email_template.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_main_email_template.tpl
@@ -1,8 +1,9 @@
 <html>
 <body style="font-family: verdana; font-size: 12px">
-
+<br />
+<br />
 {{$emailBody}}
-
+<br />
 <br />
 <br />
 --- THIS IS AN AUTOMATED MESSAGE ---


### PR DESCRIPTION
**_Hotfix PR in response to issues found in preprod:_**

The CR returns used initially worked in local but were ignored in preprod. Added <br> tags to make sure that the main_email_template has more than 10 lines.

![Screen Shot 2020-10-01 at 10 52 03 AM](https://user-images.githubusercontent.com/2892376/94826094-f4cda500-03d4-11eb-8ee1-6d1faf1d72de.png)
