### PR TITLE
hotfix/LEAF: Update gulpfile.js to Match Current Config Used in USWDS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ USWDS SASS GULPFILE
 */
 
 const autoprefixer = require("autoprefixer");
-const autoprefixerOptions = require("./node_modules/uswds-gulp/config/browsers");
 const csso = require("postcss-csso");
 const gulp = require("gulp");
 const pkg = require("./node_modules/uswds/package.json");
@@ -59,7 +58,10 @@ gulp.task("icons", () => {
 gulp.task("build-sass", function(done) {
   var plugins = [
     // Autoprefix
-    autoprefixer(autoprefixerOptions),
+    autoprefixer({
+      cascade: false,
+      grid: true
+    }),
     // Minify
     csso({ forceMediaMerge: false })
   ];


### PR DESCRIPTION
Hotfix: The configuration of the gulpfile on LEAF was different from the version found on uswds github gulp repo.

- Update to gulpfile.js to match current config found on uswds gulp. 
- Removed autoPrefixerOptions and changed plugins config.