### PR TITLE
LEAF-1802: Enable UTF-8 locale for LEAF pod

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -15,6 +15,13 @@ RUN apt-get update && apt-get install -y libpng-dev zlib1g-dev git subversion zl
 COPY /docker/php/trust_ca_certs.sh /tmp/
 RUN bash -xc "bash /tmp/trust_ca_certs.sh"
 
+RUN apt-get install -y locales && locale-gen en_US.UTF-8
+RUN bash -xc 'echo LANG="en_US.UTF-8" > /etc/default/locale' 
+ENV LANGUAGE "en_US.UTF-8"
+ENV LANG "en_US.UTF-8"
+ENV LC_ALL "en_US.UTF-8"
+RUN bash -xc 'locale -a' # testing
+
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/certs/leaf.key -out /etc/ssl/certs/leaf.pem -subj "/C=US/ST=VA/L=Chantilly/O=LEAF/OU=LEAF/CN=%"
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
LEAF-1802: Enable UTF-8 locale for LEAF pod

LEAF pod is currently unable to resolve filename characters that are encoded in UTF-8.

Such files have been saved to the ./UPLOADS directory as user provided strings. Users have
been able to upload files in UTF-8, however, system commands such as ls and cd have not been able
to decode the text names of these filenames.  This PR defaults the operating system environment
to en_US.UTF-8 to support these files.

Further testing will be needed to ensure files are accessible after this change is inplace, and that this change
is compatible with both how filenames are encoded in the database; currently both latin1_swedish_ci and utf8_general_ci.


Also resolves following errors from `aws s3 sync` commands:

![image](https://user-images.githubusercontent.com/59398225/95385052-72088680-08bb-11eb-88cf-f735c439194c.png)

