### PR TITLE
[Bugfix][LEAF-1876] make launchpad scripts work in stateless

### DIFF
--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -1033,7 +1033,7 @@ class FormWorkflow
                         global $config;
                     
                         $cleanPortalPath = str_replace("/", "_", $config->portalPath);
-                        $eventFile = $this->eventFolder . 'CustomEvent_' . $cleanPortalPath . $event['eventID'] . '.php';
+                        $eventFile = $this->eventFolder . 'CustomEvent_' . $cleanPortalPath . "_" . $event['eventID'] . '.php';
                     }
 
                     if (is_file($eventFile))

--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -1033,7 +1033,7 @@ class FormWorkflow
                         global $config;
                     
                         $cleanPortalPath = str_replace("/", "_", $config->portalPath);
-                        $eventFile = $this->eventFolder . 'CustomEvent_' . $cleanPortalPath . "_" . $event['eventID'] . '.php';
+                        $eventFile = $this->eventFolder . 'CustomEvent_' . $cleanPortalPath . '_' . $event['eventID'] . '.php';
                     }
 
                     if (is_file($eventFile))


### PR DESCRIPTION
Fix for accessing workflow custom scripts by adding ```_``` to filename