### PR TITLE
Hotfix/config bypass fix for local

### DIFF
--- a/index.php
+++ b/index.php
@@ -55,8 +55,9 @@ $imagesPos = strpos($uri, '/images/');
 if ($cssPos !== false || $jsPos !== false || $imagesPos !== false) {
     $orgchartPos = strpos($sitePath, '/orgchart/');
     $nationalPhonePos = strpos($sitePath, '/orgchart_phone/');
+    $localOrgchartPos = strpos($sitePath, '/LEAF_Nexus/');
     
-    if($orgchartPos !== false || $nationalPhonePos !== false)
+    if($orgchartPos !== false || $nationalPhonePos !== false || $localOrgchartPos !== false)
     {
         $leafRoutes = new LEAFRoutes('orgchart');
     }

--- a/index.php
+++ b/index.php
@@ -49,15 +49,13 @@ if(count($matches)){
 }
 
 //skip config lookup if looking for static files
-$cssPos = strpos($uri, '/css/');
-$jsPos = strpos($uri, '/js/');
-$imagesPos = strpos($uri, '/images/');
-if ($cssPos !== false || $jsPos !== false || $imagesPos !== false) {
-    $orgchartPos = strpos($sitePath, '/orgchart/');
-    $nationalPhonePos = strpos($sitePath, '/orgchart_phone/');
-    $localOrgchartPos = strpos($sitePath, '/LEAF_Nexus/');
+$pattern = '(' . addslashes(implode("|",Routing_Config::$configBypassArray)) . ')';
+preg_match ($pattern , $uri, $matches, PREG_OFFSET_CAPTURE);
+if (count($matches)) {
+    $pattern = '(' . addslashes(implode("|",Routing_Config::$orgchartArray)) . ')';
+    preg_match ($pattern , $sitePath, $matches, PREG_OFFSET_CAPTURE);
     
-    if($orgchartPos !== false || $nationalPhonePos !== false || $localOrgchartPos !== false)
+    if(count($matches))
     {
         $leafRoutes = new LEAFRoutes('orgchart');
     }

--- a/routing/routing_config.php
+++ b/routing/routing_config.php
@@ -32,5 +32,19 @@ if (!defined('DATABASE_DB_CONFIG')) define('DATABASE_DB_CONFIG',    getenv('DATA
             '/[^/]*.php',
             '/[^/]*.ico'
         ];
+
+        //array of url segments that denote that the config db call can be bypassed  
+        public static $configBypassArray = [
+            '/js/',
+            '/css/',
+            '/images/'
+        ];
+
+        //array of url segments that denote that the call is to an orgchart   
+        public static $orgchartArray = [
+            '/orgchart/',
+            '/orgchart_phone/',
+            '/LEAF_Nexus/'
+        ];
     }
 


### PR DESCRIPTION
Since the orgchart link locally is LEAF_Nexus, we need to add this condition to the config bypass. It may be cleaner to rename the LEAF_Nexus directory to Orgchart, but  I think it's smarter to do that after we finish the stateless transition.

I also added the config bypass strings and orgchart strings to the routing_config.