### PR TITLE
Modify updateProgress to contain trailing slash in stateless API

### DIFF
--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -226,7 +226,7 @@ function getIndicator(indicatorID, series) {
 function updateProgress() {
     $.ajax({
         type: 'GET',
-        url: "./api/form/<!--{$recordID|strip_tags}-->/progress",
+        url: "./api/form/<!--{$recordID|strip_tags}-->/progress/",
         dataType: 'json',
         success: function(response) {
             if(response < 100) {


### PR DESCRIPTION
Modifies client-code to contain trailing slash for endpoint /progress/

Eliminates 301 redirect sent under Stateless, reducing needless requests-response cycle from browser