### PR TITLE
Bump FPM process limits and enable status page

### DIFF
--- a/docker/php/etc/www.conf
+++ b/docker/php/etc/www.conf
@@ -111,22 +111,22 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 5
+; pm.max_children = 5
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
 ; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
-pm.start_servers = 3
+; pm.start_servers = 3
 
 ; The desired minimum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.min_spare_servers = 2
+; pm.min_spare_servers = 2
 
 ; The desired maximum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.max_spare_servers = 4
+; pm.max_spare_servers = 4
 
 ; The number of seconds after which an idle process will be killed.
 ; Note: Used only when pm is set to 'ondemand'
@@ -442,3 +442,11 @@ clear_env = no
 ;emergency_restart_threshold 10
 ;emergency_restart_interval 1m
 ;process_control_timeout 10s
+
+ping.response = pong
+ping.path = /ping
+pm.status_path = /status
+pm.max_children=32
+pm.min_spare_servers=4
+pm.max_spare_servers=8
+


### PR DESCRIPTION
Bump FPM process limits and enable status page

Bumping FPM max children to 32 to resolve bad gateway errors