### PR TITLE
hotfix/protected-data-search

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -442,6 +442,7 @@ var currentIndicator = {};
 function editIndicatorPrivileges(indicatorID) {
     dialog_simple.setContent('<h2>Special access restrictions for this field</h2>'
                             + '<p>These restrictions will limit view access to the request initiator and members of any groups you specify.</p>'
+                            + '<p>Additionally, these restrictions will only allow the groups specified below to apply search filters for this field.</p>'
                             + 'All others will see "[protected data]".<br /><div id="indicatorPrivs"></div>');
 
     dialog_simple.indicateBusy();

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2731,6 +2731,11 @@ class Form
                     $tResTypeHint = array();
                     if ($q['indicatorID'] > 0)
                     {
+                        // check protected field mask, ignore query if masked
+                        if($this->isMasked($q['indicatorID'])) {
+                            continue 2;
+                        }
+
                         // need data type hint and default data
                         $tVarTypeHint = array(':indicatorID' => $q['indicatorID']);
                         $tResTypeHint = $this->db->prepared_query('SELECT format, `default` FROM indicators


### PR DESCRIPTION
Applies indicator masks to report builder queries, and updates its description to describe the new behavior.