### PR TITLE
hotfix/LEAF-1930: IE11 Fix for Custom 404 Page

### DIFF
--- a/error_404.php
+++ b/error_404.php
@@ -6,6 +6,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <title>LEAF - Page Not Found</title>
     <link rel="stylesheet" href="/libs/css/leaf.css" />
     <link rel="icon" href="../vafavicon.ico" type="image/x-icon" />


### PR DESCRIPTION
IE11 is opening the new 404 page in Compatibility Mode which does not display the page's styling correctly. Added a meta tag to the page intended to force IE11 to display in the most up to date version of IE.

https://stackoverflow.com/questions/52775004/forcing-ies-compatibility-mode-off