### PR TITLE
Removing max length

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_sitemaps_template.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_sitemaps_template.tpl
@@ -133,7 +133,7 @@
         dialog.setContent('<div>' +
             '<div class="leaf-marginAll-1rem"><div role="heading" class="leaf-bold">Card Title</div><input id="button-title" size="48" maxlength="27"></input></div>' +
             '<div class="leaf-marginAll-1rem"><div role="heading" class="leaf-bold">Card Description</div><input aria-label="Enter group name" id="button-description" size="48" maxlength="48"></input></div>' +
-            '<div class="leaf-marginAll-1rem"><div role="heading" class="leaf-bold">Target Site Address</div><input id="button-target" size="48"></input></div>' +
+            '<div class="leaf-marginAll-1rem"><div role="heading" class="leaf-bold">Target Site Address</div><input id="button-target" size="48" maxlength="2048"></input></div>' +
             '<div class="leaf-marginAll-1rem"><div role="heading" id="button-color" class="leaf-bold">Card Color</div>' +
                 '<div class="leaf-float-left" style="margin-right: 3rem;">' +
                 '<div class="leaf-color-choice"><span class="leaf-color-demo leaf-card-white"></span><input type="radio" id="white" name="btnColor" value="leaf-card-white" checked><label for="white">White</label></div>' +

--- a/LEAF_Request_Portal/templates/reports/LEAF_sitemaps_template.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_sitemaps_template.tpl
@@ -133,7 +133,7 @@
         dialog.setContent('<div>' +
             '<div class="leaf-marginAll-1rem"><div role="heading" class="leaf-bold">Card Title</div><input id="button-title" size="48" maxlength="27"></input></div>' +
             '<div class="leaf-marginAll-1rem"><div role="heading" class="leaf-bold">Card Description</div><input aria-label="Enter group name" id="button-description" size="48" maxlength="48"></input></div>' +
-            '<div class="leaf-marginAll-1rem"><div role="heading" class="leaf-bold">Target Site Address</div><input id="button-target" size="48" maxlength="40"></input></div>' +
+            '<div class="leaf-marginAll-1rem"><div role="heading" class="leaf-bold">Target Site Address</div><input id="button-target" size="48"></input></div>' +
             '<div class="leaf-marginAll-1rem"><div role="heading" id="button-color" class="leaf-bold">Card Color</div>' +
                 '<div class="leaf-float-left" style="margin-right: 3rem;">' +
                 '<div class="leaf-color-choice"><span class="leaf-color-demo leaf-card-white"></span><input type="radio" id="white" name="btnColor" value="leaf-card-white" checked><label for="white">White</label></div>' +

--- a/libs/sass/0-leaf.scss
+++ b/libs/sass/0-leaf.scss
@@ -116,6 +116,9 @@ button:focus, button:active {border: 0!important; outline: none!important;}
 .leaf-title-inst {font-family: 'PublicSans-Regular'; font-size: 0.8rem; margin-left: 0.7rem; display: inline-block;}
 
 /* ############### LEAF SITEMAP STYLES ################# */
+.edit-card {
+    cursor: move;
+}
 .leaf-sitemap-card {
     flex: 0 1 30%;
     min-width: 20rem;
@@ -126,7 +129,6 @@ button:focus, button:active {border: 0!important; outline: none!important;}
     border: 1px solid #ccc;
     height: 5.8rem;
     background-color: #fff;
-    cursor: move;
     border-radius: 5px;
     transition: box-shadow 0.4s ease;
     white-space: wrap;


### PR DESCRIPTION
In addition to capping max URL length at 2048 characters , noticed that the move cursor was showing when viewing the sitemap.  Fixed the CSS to only show that during edit.