### PR TITLE
hotfix/login_handling

### DIFF
--- a/LEAF_Request_Portal/index.php
+++ b/LEAF_Request_Portal/index.php
@@ -39,11 +39,9 @@ $login->loginUser();
 if (!$login->isLogin() || !$login->isInDB())
 {
     echo 'Session expired, please refresh the page.<br /><br />If this message persists, please contact your administrator.';
-    // echo 'Session expired, please refresh the page.<br /><br />If this message persists, please include the following information to your administrator:';
-    // echo '<pre>';
-    //print_r($_SESSION);
-    //echo '</pre>';
-    $login->logout();
+    echo '<br />' . $login->getName();
+    echo '<br />' . $login->getUserID();
+    $login->logout(); // destroy current session tokens
     exit;
 }
 

--- a/LEAF_Request_Portal/report.php
+++ b/LEAF_Request_Portal/report.php
@@ -43,7 +43,10 @@ $login = new Login($db_phonebook, $db);
 $login->loginUser();
 if (!$login->isLogin() || !$login->isInDB())
 {
-    echo 'Your login is not recognized. Your server administrator may need to verify that your account is in the correct Active Directory group.<br />';
+    echo 'Session expired, please refresh the page.<br /><br />If this message persists, please contact your administrator.';
+    echo '<br />' . $login->getName();
+    echo '<br />' . $login->getUserID();
+    $login->logout(); // destroy current session tokens
     exit;
 }
 


### PR DESCRIPTION
This resolves an issue where session tokens are not fully destroyed upon login failure for the report.php entry point.