### PR TITLE
LEAF-1458 - Adding sendback email backups to list upon rejection

### DIFF
--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -488,9 +488,9 @@ class FormWorkflow
                     if ($resPerson[0]['userID'] != $this->login->getUserID())
                     {
                         $empUID = $this->getEmpUIDByUserName($resPerson[0]['userID']);
-                                                                
+
                         $userAuthorized = $this->checkIfBackup($empUID);
-    
+
                         if (!$userAuthorized)
                         {
                             return array('status' => 0, 'errors' => array('User account does not match'));
@@ -822,9 +822,29 @@ class FormWorkflow
 
             $requester = $dir->lookupLogin($record[0]['userID']);
             $author = $dir->lookupLogin($this->login->getUserID());
-
             $email->addRecipient($requester[0]['Email']);
             $email->addRecipient($author[0]['Email']);
+
+            // Get backups to requester so they can be notified as well
+            $nexusDB = $this->login->getNexusDB();
+            $vars = array(
+              ':reqEmpUID'  => $requester[0]['empUiD'],
+              ':authEmpUID' => $author[0]['empUID']
+            );
+            $backupIds = $nexusDB->prepared_query(
+              'SELECT DISTINCT backupEmpUID FROM relation_employee_backup
+               WHERE empUID IN (:reqEmpUID, :authEmpUID)', $vars);
+
+            // Add backups to email recepients
+            foreach($backupIds as $backup) {
+              // Don't re-email requestor or author if they are backups of each other
+              if (($backup['backupEmpUID'] != $author[0]['empUID']) &&
+                ($backup['backupEmpUID'] != $requester[0]['empID'])) {
+                  $theirBackup = $dir->lookupEmpUID($backup['backupEmpUID']);
+                  $email->addRecipient($theirBackup[0]['Email']);
+              }
+            }
+
             $email->setSender($author[0]['Email']);
 
             $email->sendMail();


### PR DESCRIPTION
Determined in testing, not from the initial request, that when a step is rejected, the requestor and rejector, as well as their backups, should be notified. 