### PR TITLE
Remove condition when querying non-empty string

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2805,7 +2805,7 @@ class Form
                     {
                         if ($operator == '!=' && $vars[':data' . $count] == '')
                         {
-                            $conditions .= "{$gate}(lj_data{$count}.data {$operator} :data{$count} OR lj_data{$count}.data IS NOT NULL)";
+                            $conditions .= "{$gate}(lj_data{$count}.data {$operator} :data{$count})";
                         }
                         else
                         {


### PR DESCRIPTION
This resolves an issue where users querying for non-empty strings incorrectly get empty strings as results.