### PR TITLE
LEAF-2479 sticky menus, overflow fix

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -850,7 +850,10 @@ button.tools:hover, button.tools:focus{
 #category_list>div>img {
     vertical-align: middle;
 }
-
+/* keeps content from overlapping menu */
+#formcontent > .printmainform{
+   overflow: hidden;
+}
 .toolbar_right {
     float: right;
 }
@@ -1309,4 +1312,40 @@ div.sensitiveIndicator > .printResponse {
     color: white;
     padding: 4px;
     font-weight: bold;
+}
+
+/* fixes an issue where iframes extend outside the container (file upload fields) */
+.col.span_3_of_5 iframe {
+    width: 100%;
+    min-width: 400px;
+}
+fieldset iframe {
+    width: 100%;
+}
+/* sticky menu on edit page */
+.col.span_3_of_5 > div {
+    position: relative;
+}
+#progressArea {
+    position: sticky;
+    z-index: 100;
+    top: 0;
+}
+/* sticky top of dialog box */
+form [id^="LeafForm"][id$="_record"] > div {
+    position: relative;
+    padding-top: 30px;
+}
+#form-xhr-cancel-save-menu {
+    position: absolute;
+    left: 0;
+    padding-top: 3px;
+    display: flex;
+    width: 100%;
+    background-color: white;
+    justify-content: space-between;
+    z-index: 1000;
+}
+#form-xhr-cancel-save-menu button {
+    margin: 0.25em 0.5em;
 }

--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -14,9 +14,10 @@ var LeafForm = function(containerID) {
 	$('#' + containerID).html('<div id="'+prefixID+'xhrDialog" style="display: none; background-color: white; border-style: none solid solid; border-width: 0 1px 1px; border-color: #e0e0e0; padding: 4px">\
 			<form id="'+prefixID+'record" enctype="multipart/form-data" action="javascript:void(0);">\
 			    <div>\
-			        <button id="'+prefixID+'button_cancelchange" class="buttonNorm" style="position: absolute; left: 10px"><img src="../libs/dynicons/?img=process-stop.svg&amp;w=16" alt="cancel" /> Cancel</button>\
-			        <button id="'+prefixID+'button_save" class="buttonNorm" style="position: absolute; right: 10px"><img src="../libs/dynicons/?img=media-floppy.svg&amp;w=16" alt="save" /> Save Change</button>\
-			        <div style="border-bottom: 2px solid black; line-height: 30px"><br /></div>\
+			    	<div id="form-xhr-cancel-save-menu" style="border-bottom: 2px solid black; height: 30px">\
+			        	<button id="'+prefixID+'button_cancelchange" class="buttonNorm" ><img src="../libs/dynicons/?img=process-stop.svg&amp;w=16" alt="cancel" /> Cancel</button>\
+			        	<button id="'+prefixID+'button_save" class="buttonNorm"><img src="../libs/dynicons/?img=media-floppy.svg&amp;w=16" alt="save" /> Save Change</button>\
+			        </div>\
 			        <div id="'+prefixID+'loadIndicator" style="visibility: hidden; position: absolute; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; height: 300px; width: 460px">Loading... <img src="images/largespinner.gif" alt="loading..." /></div>\
 			        <div id="'+prefixID+'xhr" style="min-width: 540px; min-height: 420px; padding: 8px; overflow: auto"></div>\
 			    </div>\

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -744,6 +744,14 @@ $(function() {
     updateProgress();
     <!--{/if}-->
 
+    //scroll event for dialog menu
+    let elParentForm = document.querySelector('[id^="LeafForm"][id$="_record"]');
+    let elFormMenu = document.getElementById('form-xhr-cancel-save-menu');
+    window.addEventListener('scroll', function(){
+        if (elParentForm && elFormMenu){
+            let parent_Y = elParentForm.getBoundingClientRect().y;
+            elFormMenu.style.top = parent_Y > 0 ? 0 : (-1 * parent_Y) + "px";
+        }
+    });
 });
-
 </script>


### PR DESCRIPTION
Adding styling, and some JS, for Edit Form page view and edit form dialog box to sticky the progress / save / cancel menu. 
Also added some minor styling to fix current issues with content overflow.  